### PR TITLE
feat: event upcasting + docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,4 +69,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,4 +282,3 @@ jobs:
             - [Documentation](https://mapyr.github.io/mcp-hangar/)
           prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' }}
           generate_release_notes: true
-

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -102,4 +102,3 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -144,4 +144,3 @@ jobs:
           else
             echo "⚠️ Dry run - no changes made." >> $GITHUB_STEP_SUMMARY
           fi
-

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ providers:
     mode: subprocess
     command: [python, -m, my_math_server]
     idle_ttl_s: 300
-    
+
   sqlite:
     mode: container
     image: ghcr.io/modelcontextprotocol/server-sqlite:latest
@@ -245,11 +245,11 @@ observability:
     public_key: ${LANGFUSE_PUBLIC_KEY}
     secret_key: ${LANGFUSE_SECRET_KEY}
     host: https://cloud.langfuse.com
-    
+
   tracing:
     enabled: true
     otlp_endpoint: http://localhost:4317
-    
+
   metrics:
     enabled: true
     endpoint: /metrics
@@ -293,4 +293,3 @@ uv run pytest tests/ -v
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.
-

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -49,8 +49,8 @@ registry_invoke(provider="math", tool="add", arguments={"a": 1, "b": 2})
 ```
 # Automatic retry on transient failures + progress tracking + tracing
 registry_invoke_ex(
-  provider="sqlite", 
-  tool="query", 
+  provider="sqlite",
+  tool="query",
   arguments={"sql": "SELECT * FROM users"},
   max_retries=3,
   correlation_id="my-trace-001"  # Optional: for distributed tracing
@@ -60,8 +60,8 @@ registry_invoke_ex(
 # - result: the actual result
 # - _retry_metadata: {
 #     "correlation_id": "my-trace-001",
-#     "attempts": 1, 
-#     "total_time_ms": 234.5, 
+#     "attempts": 1,
+#     "total_time_ms": 234.5,
 #     "retries": []
 #   }
 # - _progress: [{"stage": "ready", "message": "...", "elapsed_ms": 0.1}, ...]
@@ -81,7 +81,7 @@ registry_invoke_ex(
 # See progress WHILE the operation runs
 registry_invoke_stream(
   provider="sqlite",
-  tool="query", 
+  tool="query",
   arguments={"sql": "SELECT * FROM large_table"},
   correlation_id="stream-trace-001"
 )
@@ -152,7 +152,7 @@ registry_invoke(provider="filesystem", tool="move_file", arguments={"source": "/
 
 Build persistent knowledge that survives conversations:
 
-> **💾 Stateful Provider**: Memory data is automatically persisted to `./data/memory/`. 
+> **💾 Stateful Provider**: Memory data is automatically persisted to `./data/memory/`.
 > Your knowledge graph survives restarts and is available across sessions.
 
 ```
@@ -183,7 +183,7 @@ registry_invoke(provider="memory", tool="create_relations", arguments={
 registry_invoke(provider="memory", tool="delete_entities", arguments={"entityNames": ["OldProject"]})
 ```
 
-**Use cases**: 
+**Use cases**:
 - Track test results and findings
 - Build documentation as you work
 - Create relationship maps between concepts

--- a/docker/Dockerfile.sqlite
+++ b/docker/Dockerfile.sqlite
@@ -17,4 +17,3 @@ RUN mkdir -p /data && chmod 777 /data
 ENV SQLITE_DB_PATH=/data/database.db
 
 ENTRYPOINT ["mcp-server-sqlite"]
-

--- a/docs/adr/001-langfuse-integration.md
+++ b/docs/adr/001-langfuse-integration.md
@@ -1,7 +1,7 @@
 # ADR-001: Langfuse Integration for LLM Observability
 
-**Status:** Accepted  
-**Date:** 2026-01-12  
+**Status:** Accepted
+**Date:** 2026-01-12
 **Authors:** MCP Hangar Team
 
 ## Context
@@ -111,4 +111,3 @@ result = traced_service.invoke_tool(
 - [MCP Protocol Specification](https://modelcontextprotocol.io/specification)
 - [ObservabilityPort Implementation](/mcp_hangar/application/ports/observability.py)
 - [LangfuseAdapter Implementation](/mcp_hangar/infrastructure/observability/langfuse_adapter.py)
-

--- a/docs/architecture/EVENT_SOURCING.md
+++ b/docs/architecture/EVENT_SOURCING.md
@@ -1,0 +1,110 @@
+# Event Sourcing
+
+MCP Hangar persists domain events in an append-only Event Store. This supports auditing, projections, and rebuilding state from history.
+
+## Persistence format
+
+Events are serialized as JSON and stored with:
+
+- `stream_id` (e.g. `provider:math`)
+- `stream_version` (0-based, optimistic concurrency)
+- `event_type` (e.g. `ProviderStarted`)
+- `data` (JSON payload)
+
+### Schema versioning
+
+Every serialized payload includes a schema version field:
+
+```json
+{
+  "_version": 1,
+  "provider_id": "math",
+  "mode": "subprocess",
+  "tools_count": 3,
+  "startup_duration_ms": 50.0
+}
+```
+
+Backwards compatibility rule:
+
+- Events persisted without `_version` are treated as **v1**.
+
+## Upcasting (schema evolution)
+
+When schemas evolve between releases, older persisted events might not match the current event constructor signature.
+
+MCP Hangar supports **upcasting**: converting an event payload from an older schema version to the current one **at read time**.
+
+### Rules
+
+- Upcasting only happens on **read** (deserialization).
+- Upcasters are **pure functions** (no I/O, no time dependence).
+- Upcasters must advance **exactly one version step**: `vN -> vN+1`.
+- Updating `EVENT_VERSION_MAP` requires providing the full upcaster chain.
+
+### Where versions are defined
+
+Current schema versions live in:
+
+- `mcp_hangar/infrastructure/persistence/event_serializer.py`
+  - `EVENT_VERSION_MAP`
+  - `get_current_version(event_type)`
+
+### Writing an upcaster
+
+Create an upcaster in `mcp_hangar/infrastructure/persistence/upcasters/`:
+
+```python
+from typing import Any
+
+from mcp_hangar.infrastructure.persistence.event_upcaster import IEventUpcaster
+
+
+class ProviderStartedV1ToV2(IEventUpcaster):
+    """Example evolution: add a `tags` field introduced in v2."""
+
+    @property
+    def event_type(self) -> str:
+        return "ProviderStarted"
+
+    @property
+    def from_version(self) -> int:
+        return 1
+
+    @property
+    def to_version(self) -> int:
+        return 2
+
+    def upcast(self, data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "tags": []}
+```
+
+### Registering upcasters (composition root)
+
+Upcaster chain is built at startup:
+
+```python
+from mcp_hangar.infrastructure.persistence import EventSerializer, SQLiteEventStore
+from mcp_hangar.infrastructure.persistence.event_upcaster import UpcasterChain
+
+from mcp_hangar.infrastructure.persistence.upcasters.provider_started import ProviderStartedV1ToV2
+
+
+chain = UpcasterChain()
+chain.register(ProviderStartedV1ToV2())
+
+serializer = EventSerializer(upcaster_chain=chain)
+store = SQLiteEventStore(db_path, serializer=serializer)
+```
+
+### Forward compatibility (extra payload keys)
+
+Deserializer ignores unknown payload keys when reconstructing event instances. This means newer payloads can contain additional fields without breaking older code paths.
+
+## Troubleshooting
+
+- `UpcastingError: Missing upcaster...` usually means:
+  - `EVENT_VERSION_MAP` was bumped, but the full set of upcasters was not registered.
+- If you need to rename an event type, treat it as a new type and keep the old one readable via:
+  - keeping the old `event_type` registered in `EVENT_TYPE_MAP`, or
+  - a custom adapter at the serialization boundary.

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -122,7 +122,7 @@ class StdioClient:
         request_id = uuid4()
         queue = Queue(maxsize=1)
         pending[request_id] = PendingRequest(queue)
-        
+
         write({"id": request_id, "method": method, ...})
         return queue.get(timeout=timeout)
 
@@ -162,4 +162,3 @@ with lock:
 **Recommended TTL:**
 - Subprocess: 180-300s
 - Container: 300-600s
-

--- a/docs/guides/CONTAINERS.md
+++ b/docs/guides/CONTAINERS.md
@@ -164,4 +164,3 @@ Or set `MCP_CI_RELAX_VOLUME_PERMS=true`.
 |----------|---------|-------------|
 | `MCP_CONTAINER_RUNTIME` | auto | Force `podman` or `docker` |
 | `MCP_CI_RELAX_VOLUME_PERMS` | `false` | Chmod 777 on volumes (CI) |
-

--- a/docs/guides/DISCOVERY.md
+++ b/docs/guides/DISCOVERY.md
@@ -9,7 +9,7 @@ discovery:
   enabled: true
   refresh_interval_s: 30
   auto_register: true
-  
+
   sources:
     - type: docker
       mode: additive
@@ -162,4 +162,3 @@ discovery:
 | `mcp_hangar_discovery_registrations_total` | New registrations |
 | `mcp_hangar_discovery_errors_total` | Errors by source |
 | `mcp_hangar_discovery_latency_seconds` | Cycle duration |
-

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -84,7 +84,7 @@ import pytest
 def test_database_operations(postgres_container):
     """Test with real PostgreSQL database."""
     dsn = postgres_container["dsn"]
-    
+
     import asyncpg
     conn = await asyncpg.connect(dsn)
     result = await conn.fetchval("SELECT 1")
@@ -103,12 +103,12 @@ def test_langfuse_tracing(langfuse_config, langfuse_container, http_client):
     from mcp_hangar.infrastructure.observability.langfuse_adapter import (
         LangfuseObservabilityAdapter,
     )
-    
+
     adapter = LangfuseObservabilityAdapter(langfuse_config)
     span = adapter.start_tool_span("test", "tool", {"arg": 1})
     span.end_success({"result": "ok"})
     adapter.flush()
-    
+
     # Query Langfuse API
     response = http_client.get(
         f"{langfuse_container['url']}/api/public/traces",
@@ -228,4 +228,3 @@ providers:
 ```bash
 pytest tests/ -v --timeout=60
 ```
-

--- a/docs/runbooks/RELEASE.md
+++ b/docs/runbooks/RELEASE.md
@@ -271,4 +271,3 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 | Date | Change | Author |
 |------|--------|--------|
 | 2026-01-12 | Initial runbook creation | CI/CD Setup |
-

--- a/examples/discovery/Dockerfile.test-provider
+++ b/examples/discovery/Dockerfile.test-provider
@@ -62,4 +62,3 @@ EOF
 
 # Default command - run MCP server via stdio
 CMD ["python", "/app/server.py"]
-

--- a/examples/discovery/docker-compose.podman.yml
+++ b/examples/discovery/docker-compose.podman.yml
@@ -38,4 +38,3 @@ services:
 networks:
   mcp-net:
     driver: bridge
-

--- a/examples/discovery/docker-compose.yml
+++ b/examples/discovery/docker-compose.yml
@@ -48,4 +48,3 @@ services:
 networks:
   mcp-network:
     driver: bridge
-

--- a/examples/discovery/kubernetes-deployment.yaml
+++ b/examples/discovery/kubernetes-deployment.yaml
@@ -158,7 +158,7 @@ data:
       enabled: true
       refresh_interval_s: 30
       auto_register: true
-      
+
       sources:
         - type: kubernetes
           mode: authoritative
@@ -166,13 +166,12 @@ data:
             - mcp-providers
           label_selector: "app.kubernetes.io/component=mcp-provider"
           in_cluster: true
-      
+
       security:
         max_providers_per_source: 100
         require_health_check: true
         quarantine_on_failure: true
-        
+
         denied_namespaces:
           - kube-system
           - default
-

--- a/examples/discovery/provider-http.yaml
+++ b/examples/discovery/provider-http.yaml
@@ -16,4 +16,3 @@ metadata:
   version: "2.1.0"
   environment: development
   description: Remote HTTP MCP provider
-

--- a/examples/discovery/provider-subprocess.yaml
+++ b/examples/discovery/provider-subprocess.yaml
@@ -19,4 +19,3 @@ metadata:
   owner: platform-team
   version: "1.0.0"
   description: Custom math operations provider
-

--- a/mcp_hangar/__init__.py
+++ b/mcp_hangar/__init__.py
@@ -71,14 +71,7 @@ from .progress import (
     ProgressStage,
     ProgressTracker,
 )
-from .retry import (
-    BackoffStrategy,
-    get_retry_policy,
-    get_retry_store,
-    RetryPolicy,
-    RetryResult,
-    with_retry,
-)
+from .retry import BackoffStrategy, get_retry_policy, get_retry_store, RetryPolicy, RetryResult, with_retry
 from .stdio_client import StdioClient
 
 __all__ = [

--- a/mcp_hangar/application/discovery/__init__.py
+++ b/mcp_hangar/application/discovery/__init__.py
@@ -7,12 +7,7 @@ including the orchestrator, security validation, and metrics.
 from .discovery_metrics import DiscoveryMetrics
 from .discovery_orchestrator import DiscoveryConfig, DiscoveryOrchestrator
 from .lifecycle_manager import DiscoveryLifecycleManager
-from .security_validator import (
-    SecurityConfig,
-    SecurityValidator,
-    ValidationReport,
-    ValidationResult,
-)
+from .security_validator import SecurityConfig, SecurityValidator, ValidationReport, ValidationResult
 
 __all__ = [
     "DiscoveryOrchestrator",

--- a/mcp_hangar/application/discovery/discovery_orchestrator.py
+++ b/mcp_hangar/application/discovery/discovery_orchestrator.py
@@ -11,10 +11,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 
 from mcp_hangar.domain.discovery.conflict_resolver import ConflictResolver
 from mcp_hangar.domain.discovery.discovered_provider import DiscoveredProvider
-from mcp_hangar.domain.discovery.discovery_service import (
-    DiscoveryCycleResult,
-    DiscoveryService,
-)
+from mcp_hangar.domain.discovery.discovery_service import DiscoveryCycleResult, DiscoveryService
 from mcp_hangar.domain.discovery.discovery_source import DiscoverySource
 from mcp_hangar.logging_config import get_logger
 

--- a/mcp_hangar/application/event_handlers/__init__.py
+++ b/mcp_hangar/application/event_handlers/__init__.py
@@ -1,19 +1,7 @@
 """Event handlers for reacting to domain events."""
 
-from .alert_handler import (
-    Alert,
-    AlertEventHandler,
-    AlertSink,
-    CallbackAlertSink,
-    LogAlertSink,
-)
-from .audit_handler import (
-    AuditEventHandler,
-    AuditRecord,
-    AuditStore,
-    InMemoryAuditStore,
-    LogAuditStore,
-)
+from .alert_handler import Alert, AlertEventHandler, AlertSink, CallbackAlertSink, LogAlertSink
+from .audit_handler import AuditEventHandler, AuditRecord, AuditStore, InMemoryAuditStore, LogAuditStore
 from .logging_handler import LoggingEventHandler
 from .metrics_handler import MetricsEventHandler
 from .security_handler import (

--- a/mcp_hangar/application/event_handlers/alert_handler.py
+++ b/mcp_hangar/application/event_handlers/alert_handler.py
@@ -5,13 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
-from ...domain.events import (
-    DomainEvent,
-    HealthCheckFailed,
-    ProviderDegraded,
-    ProviderStopped,
-    ToolInvocationFailed,
-)
+from ...domain.events import DomainEvent, HealthCheckFailed, ProviderDegraded, ProviderStopped, ToolInvocationFailed
 from ...logging_config import get_logger
 
 logger = get_logger(__name__)

--- a/mcp_hangar/application/event_handlers/persistent_audit_store.py
+++ b/mcp_hangar/application/event_handlers/persistent_audit_store.py
@@ -8,11 +8,7 @@ import asyncio
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from ...domain.contracts.persistence import (
-    AuditAction,
-    AuditEntry,
-    IAuditRepository,
-)
+from ...domain.contracts.persistence import AuditAction, AuditEntry, IAuditRepository
 from ...infrastructure.async_executor import submit_async
 from ...logging_config import get_logger
 from .audit_handler import AuditRecord, AuditStore

--- a/mcp_hangar/application/queries/handlers.py
+++ b/mcp_hangar/application/queries/handlers.py
@@ -16,13 +16,7 @@ from ...infrastructure.query_bus import (
     QueryHandler,
 )
 from ...logging_config import get_logger
-from ..read_models import (
-    HealthInfo,
-    ProviderDetails,
-    ProviderSummary,
-    SystemMetrics,
-    ToolInfo,
-)
+from ..read_models import HealthInfo, ProviderDetails, ProviderSummary, SystemMetrics, ToolInfo
 
 logger = get_logger(__name__)
 

--- a/mcp_hangar/application/read_models/__init__.py
+++ b/mcp_hangar/application/read_models/__init__.py
@@ -1,12 +1,6 @@
 """Read models for optimized queries."""
 
-from .provider_views import (
-    HealthInfo,
-    ProviderDetails,
-    ProviderSummary,
-    SystemMetrics,
-    ToolInfo,
-)
+from .provider_views import HealthInfo, ProviderDetails, ProviderSummary, SystemMetrics, ToolInfo
 
 __all__ = [
     "ProviderSummary",

--- a/mcp_hangar/application/sagas/provider_failover_saga.py
+++ b/mcp_hangar/application/sagas/provider_failover_saga.py
@@ -4,12 +4,7 @@ from dataclasses import dataclass
 import time
 from typing import Dict, List, Optional, Set, Type
 
-from ...domain.events import (
-    DomainEvent,
-    ProviderDegraded,
-    ProviderStarted,
-    ProviderStopped,
-)
+from ...domain.events import DomainEvent, ProviderDegraded, ProviderStarted, ProviderStopped
 from ...infrastructure.saga_manager import EventTriggeredSaga
 from ...logging_config import get_logger
 from ..commands import Command, StartProviderCommand, StopProviderCommand

--- a/mcp_hangar/application/sagas/provider_recovery_saga.py
+++ b/mcp_hangar/application/sagas/provider_recovery_saga.py
@@ -3,13 +3,7 @@
 import time
 from typing import Dict, List, Optional, Type
 
-from ...domain.events import (
-    DomainEvent,
-    HealthCheckFailed,
-    ProviderDegraded,
-    ProviderStarted,
-    ProviderStopped,
-)
+from ...domain.events import DomainEvent, HealthCheckFailed, ProviderDegraded, ProviderStarted, ProviderStopped
 from ...infrastructure.saga_manager import EventTriggeredSaga
 from ...logging_config import get_logger
 from ..commands import Command, StartProviderCommand, StopProviderCommand

--- a/mcp_hangar/domain/contracts/__init__.py
+++ b/mcp_hangar/domain/contracts/__init__.py
@@ -4,12 +4,7 @@ This module defines contracts (abstract interfaces) that the domain layer
 depends on. Implementations are provided by the infrastructure layer.
 """
 
-from .event_store import (
-    ConcurrencyError,
-    IEventStore,
-    NullEventStore,
-    StreamNotFoundError,
-)
+from .event_store import ConcurrencyError, IEventStore, NullEventStore, StreamNotFoundError
 from .metrics_publisher import IMetricsPublisher
 from .persistence import (
     AuditAction,

--- a/mcp_hangar/domain/contracts/event_store.py
+++ b/mcp_hangar/domain/contracts/event_store.py
@@ -28,9 +28,7 @@ class ConcurrencyError(Exception):
         self.stream_id = stream_id
         self.expected = expected
         self.actual = actual
-        super().__init__(
-            f"Concurrency conflict on stream '{stream_id}': " f"expected version {expected}, actual {actual}"
-        )
+        super().__init__(f"Concurrency conflict on stream '{stream_id}': expected version {expected}, actual {actual}")
 
 
 class StreamNotFoundError(Exception):

--- a/mcp_hangar/domain/model/__init__.py
+++ b/mcp_hangar/domain/model/__init__.py
@@ -1,13 +1,7 @@
 """Domain model - Aggregates and entities."""
 
 # Re-export ProviderState from value_objects for convenience
-from ..value_objects import (
-    GroupState,
-    LoadBalancerStrategy,
-    MemberPriority,
-    MemberWeight,
-    ProviderState,
-)
+from ..value_objects import GroupState, LoadBalancerStrategy, MemberPriority, MemberWeight, ProviderState
 from .aggregate import AggregateRoot
 from .circuit_breaker import CircuitBreaker, CircuitBreakerConfig, CircuitState
 from .event_sourced_provider import EventSourcedProvider, ProviderSnapshot

--- a/mcp_hangar/domain/model/provider.py
+++ b/mcp_hangar/domain/model/provider.py
@@ -25,14 +25,7 @@ from ..exceptions import (
     ToolInvocationError,
     ToolNotFoundError,
 )
-from ..value_objects import (
-    CorrelationId,
-    HealthCheckInterval,
-    IdleTTL,
-    ProviderId,
-    ProviderMode,
-    ProviderState,
-)
+from ..value_objects import CorrelationId, HealthCheckInterval, IdleTTL, ProviderId, ProviderMode, ProviderState
 from .aggregate import AggregateRoot
 from .health_tracker import HealthTracker
 from .tool_catalog import ToolCatalog, ToolSchema

--- a/mcp_hangar/domain/model/provider_group.py
+++ b/mcp_hangar/domain/model/provider_group.py
@@ -11,14 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from ...logging_config import get_logger
 from ..events import DomainEvent
-from ..value_objects import (
-    GroupId,
-    GroupState,
-    LoadBalancerStrategy,
-    MemberPriority,
-    MemberWeight,
-    ProviderState,
-)
+from ..value_objects import GroupId, GroupState, LoadBalancerStrategy, MemberPriority, MemberWeight, ProviderState
 from .aggregate import AggregateRoot
 from .circuit_breaker import CircuitBreaker, CircuitBreakerConfig
 from .load_balancer import LoadBalancer

--- a/mcp_hangar/domain/security/__init__.py
+++ b/mcp_hangar/domain/security/__init__.py
@@ -20,12 +20,7 @@ from .input_validator import (
     validate_tool_name,
     ValidationResult,
 )
-from .rate_limiter import (
-    InMemoryRateLimiter,
-    RateLimitConfig,
-    RateLimiter,
-    RateLimitResult,
-)
+from .rate_limiter import InMemoryRateLimiter, RateLimitConfig, RateLimiter, RateLimitResult
 from .sanitizer import (
     sanitize_command_argument,
     sanitize_environment_value,
@@ -33,12 +28,7 @@ from .sanitizer import (
     sanitize_path,
     Sanitizer,
 )
-from .secrets import (
-    is_sensitive_key,
-    mask_sensitive_value,
-    SecretsMask,
-    SecureEnvironment,
-)
+from .secrets import is_sensitive_key, mask_sensitive_value, SecretsMask, SecureEnvironment
 
 __all__ = [
     # Input Validation

--- a/mcp_hangar/domain/services/__init__.py
+++ b/mcp_hangar/domain/services/__init__.py
@@ -4,13 +4,7 @@
 from ..exceptions import ProviderStartError
 from .audit_service import AuditService
 from .image_builder import BuildConfig, get_image_builder, ImageBuilder
-from .provider_launcher import (
-    ContainerConfig,
-    ContainerLauncher,
-    DockerLauncher,
-    ProviderLauncher,
-    SubprocessLauncher,
-)
+from .provider_launcher import ContainerConfig, ContainerLauncher, DockerLauncher, ProviderLauncher, SubprocessLauncher
 
 __all__ = [
     "AuditService",

--- a/mcp_hangar/gc.py
+++ b/mcp_hangar/gc.py
@@ -4,19 +4,10 @@ import threading
 import time
 from typing import Any, Literal, Optional
 
-from .domain.contracts.provider_runtime import (
-    normalize_state_to_str,
-    ProviderMapping,
-    ProviderRuntime,
-)
+from .domain.contracts.provider_runtime import normalize_state_to_str, ProviderMapping, ProviderRuntime
 from .infrastructure.event_bus import get_event_bus
 from .logging_config import get_logger
-from .metrics import (
-    observe_health_check,
-    record_error,
-    record_gc_cycle,
-    record_provider_stop,
-)
+from .metrics import observe_health_check, record_error, record_gc_cycle, record_provider_stop
 
 logger = get_logger(__name__)
 

--- a/mcp_hangar/infrastructure/__init__.py
+++ b/mcp_hangar/infrastructure/__init__.py
@@ -14,10 +14,7 @@ application.commands to maintain proper layer separation.
 
 from .command_bus import CommandBus, CommandHandler, get_command_bus, reset_command_bus
 from .event_bus import EventBus, EventHandler, get_event_bus, reset_event_bus
-from .event_sourced_repository import (
-    EventSourcedProviderRepository,
-    ProviderConfigStore,
-)
+from .event_sourced_repository import EventSourcedProviderRepository, ProviderConfigStore
 from .event_store import (
     ConcurrencyError,
     EventStore,
@@ -38,14 +35,7 @@ from .query_bus import (
     QueryHandler,
     reset_query_bus,
 )
-from .saga_manager import (
-    get_saga_manager,
-    Saga,
-    SagaContext,
-    SagaManager,
-    SagaState,
-    SagaStep,
-)
+from .saga_manager import get_saga_manager, Saga, SagaContext, SagaManager, SagaState, SagaStep
 
 __all__ = [
     # Command Bus

--- a/mcp_hangar/infrastructure/knowledge_base/memory.py
+++ b/mcp_hangar/infrastructure/knowledge_base/memory.py
@@ -7,13 +7,7 @@ import json
 from typing import Any, Optional
 
 from ...logging_config import get_logger
-from .contracts import (
-    AuditEntry,
-    IKnowledgeBase,
-    KnowledgeBaseConfig,
-    MetricEntry,
-    ProviderStateEntry,
-)
+from .contracts import AuditEntry, IKnowledgeBase, KnowledgeBaseConfig, MetricEntry, ProviderStateEntry
 
 logger = get_logger(__name__)
 

--- a/mcp_hangar/infrastructure/observability/__init__.py
+++ b/mcp_hangar/infrastructure/observability/__init__.py
@@ -1,11 +1,6 @@
 """Observability infrastructure adapters."""
 
-from .langfuse_adapter import (
-    LangfuseAdapter,
-    LangfuseConfig,
-    LangfuseObservabilityAdapter,
-    LangfuseSpanHandle,
-)
+from .langfuse_adapter import LangfuseAdapter, LangfuseConfig, LangfuseObservabilityAdapter, LangfuseSpanHandle
 
 __all__ = [
     "LangfuseAdapter",

--- a/mcp_hangar/infrastructure/observability/langfuse_adapter.py
+++ b/mcp_hangar/infrastructure/observability/langfuse_adapter.py
@@ -30,11 +30,7 @@ import time
 from typing import Any
 import uuid
 
-from ...application.ports.observability import (
-    ObservabilityPort,
-    SpanHandle,
-    TraceContext,
-)
+from ...application.ports.observability import ObservabilityPort, SpanHandle, TraceContext
 
 logger = logging.getLogger(__name__)
 

--- a/mcp_hangar/infrastructure/persistence/__init__.py
+++ b/mcp_hangar/infrastructure/persistence/__init__.py
@@ -5,12 +5,10 @@ using SQLite, in-memory storage, and other backends.
 """
 
 from .audit_repository import InMemoryAuditRepository, SQLiteAuditRepository
-from .config_repository import (
-    InMemoryProviderConfigRepository,
-    SQLiteProviderConfigRepository,
-)
+from .config_repository import InMemoryProviderConfigRepository, SQLiteProviderConfigRepository
 from .database import Database, DatabaseConfig
 from .event_serializer import EventSerializationError, EventSerializer, register_event_type
+from .event_upcaster import IEventUpcaster, UpcasterChain
 from .in_memory_event_store import InMemoryEventStore
 from .recovery_service import RecoveryService
 from .sqlite_event_store import SQLiteEventStore
@@ -21,10 +19,12 @@ __all__ = [
     "DatabaseConfig",
     "EventSerializationError",
     "EventSerializer",
+    "IEventUpcaster",
     "InMemoryAuditRepository",
     "InMemoryEventStore",
     "InMemoryProviderConfigRepository",
     "RecoveryService",
+    "UpcasterChain",
     "register_event_type",
     "SQLiteAuditRepository",
     "SQLiteEventStore",

--- a/mcp_hangar/infrastructure/persistence/event_upcaster.py
+++ b/mcp_hangar/infrastructure/persistence/event_upcaster.py
@@ -1,0 +1,166 @@
+"""Event upcasting for schema evolution.
+
+Upcasting happens at read time. Persisted events may have older schema versions.
+This module provides:
+- IEventUpcaster: a pure transformer from one schema version to the next
+- UpcasterChain: resolves and applies a sequence of upcasters to reach the current schema version
+
+Design goals:
+- Pure functions (no I/O, no time dependence)
+- Fail fast with context
+- Backward compatible: missing version is treated as v1
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class UpcastingError(RuntimeError):
+    """Raised when upcasting cannot be completed."""
+
+    def __init__(
+        self,
+        *,
+        event_type: str,
+        from_version: int,
+        message: str,
+    ) -> None:
+        self.event_type = event_type
+        self.from_version = from_version
+        super().__init__(f"Upcasting failed for {event_type} from v{from_version}: {message}")
+
+
+class IEventUpcaster(ABC):
+    """Transforms event data from one schema version to the next."""
+
+    @property
+    @abstractmethod
+    def event_type(self) -> str:
+        """Event type this upcaster handles (e.g., 'ProviderStarted')."""
+
+    @property
+    @abstractmethod
+    def from_version(self) -> int:
+        """Source schema version."""
+
+    @property
+    @abstractmethod
+    def to_version(self) -> int:
+        """Target schema version."""
+
+    @abstractmethod
+    def upcast(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Transform event data from from_version to to_version.
+
+        Args:
+            data: Event payload at from_version schema.
+
+        Returns:
+            Event payload at to_version schema.
+        """
+
+
+class UpcasterChain:
+    """Chains upcasters to transform events through multiple versions."""
+
+    def __init__(self) -> None:
+        # Structure: {event_type: {from_version: upcaster}}
+        self._upcasters: dict[str, dict[int, IEventUpcaster]] = {}
+
+    def register(self, upcaster: IEventUpcaster) -> None:
+        """Register an upcaster.
+
+        Args:
+            upcaster: Upcaster instance.
+
+        Raises:
+            ValueError: If the upcaster is invalid or conflicts with an existing registration.
+        """
+        if upcaster.to_version <= upcaster.from_version:
+            raise ValueError(
+                f"Invalid upcaster {type(upcaster).__name__}: to_version must be > from_version "
+                f"(got {upcaster.from_version} -> {upcaster.to_version})",
+            )
+
+        by_type = self._upcasters.setdefault(upcaster.event_type, {})
+        existing = by_type.get(upcaster.from_version)
+        if existing is not None:
+            raise ValueError(
+                f"Upcaster conflict for {upcaster.event_type} from v{upcaster.from_version}: "
+                f"{type(existing).__name__} already registered",
+            )
+
+        by_type[upcaster.from_version] = upcaster
+        logger.debug(
+            "event_upcaster_registered",
+            event_type=upcaster.event_type,
+            from_version=upcaster.from_version,
+            to_version=upcaster.to_version,
+            upcaster=type(upcaster).__name__,
+        )
+
+    def upcast(
+        self, event_type: str, version: int, data: dict[str, Any], *, current_version: int
+    ) -> tuple[int, dict[str, Any]]:
+        """Apply all necessary upcasters to reach current version.
+
+        Args:
+            event_type: Domain event type name.
+            version: Payload schema version.
+            data: Parsed payload dictionary.
+            current_version: Current (target) schema version.
+
+        Returns:
+            Tuple of (final_version, transformed_data).
+
+        Raises:
+            UpcastingError: If an upcast step is missing or fails.
+        """
+        if version >= current_version:
+            return version, data
+
+        event_upcasters = self._upcasters.get(event_type)
+        if not event_upcasters:
+            # No upcasters registered for this type; passthrough.
+            return version, data
+
+        working_version = version
+        working_data = data
+
+        # Apply step-by-step: v1 -> v2 -> ...
+        while working_version < current_version:
+            step = event_upcasters.get(working_version)
+            if step is None:
+                raise UpcastingError(
+                    event_type=event_type,
+                    from_version=working_version,
+                    message=f"Missing upcaster to reach v{current_version}",
+                )
+
+            if step.to_version != working_version + 1:
+                raise UpcastingError(
+                    event_type=event_type,
+                    from_version=working_version,
+                    message=(
+                        f"Upcasters must advance one version at a time (got v{step.from_version} -> v{step.to_version})"
+                    ),
+                )
+
+            try:
+                working_data = step.upcast(working_data)
+            except Exception as e:
+                raise UpcastingError(
+                    event_type=event_type,
+                    from_version=working_version,
+                    message=f"Upcaster {type(step).__name__} failed: {e}",
+                ) from e
+
+            working_version = step.to_version
+
+        return working_version, working_data

--- a/mcp_hangar/infrastructure/persistence/upcasters/README.md
+++ b/mcp_hangar/infrastructure/persistence/upcasters/README.md
@@ -1,0 +1,13 @@
+# Event upcasters
+
+This directory is for concrete upcasters used to evolve persisted event payload schemas.
+
+The full documentation lives in the MkDocs site:
+
+- `docs/architecture/EVENT_SOURCING.md`
+
+Quick rules:
+
+- Upcasting happens on read (deserialization).
+- Each upcaster is a pure function and advances exactly one version (`vN -> vN+1`).
+- Bumping `EVENT_VERSION_MAP` requires registering a complete upcaster chain.

--- a/mcp_hangar/infrastructure/persistence/upcasters/__init__.py
+++ b/mcp_hangar/infrastructure/persistence/upcasters/__init__.py
@@ -1,0 +1,7 @@
+"""Concrete event upcasters.
+
+Register upcasters at startup (composition root) by importing modules from this package
+and calling ``UpcasterChain.register(...)``.
+
+This package is intentionally infrastructure-only.
+"""

--- a/mcp_hangar/server/__init__.py
+++ b/mcp_hangar/server/__init__.py
@@ -40,15 +40,7 @@ from .bootstrap import (  # Internal functions exported for backward compatibili
 from .cli import CLIConfig, parse_args
 from .config import load_config, load_config_from_file, load_configuration
 from .lifecycle import run_server, ServerLifecycle
-from .state import (
-    COMMAND_BUS,
-    EVENT_BUS,
-    get_runtime,
-    GROUPS,
-    PROVIDER_REPOSITORY,
-    PROVIDERS,
-    QUERY_BUS,
-)
+from .state import COMMAND_BUS, EVENT_BUS, get_runtime, GROUPS, PROVIDER_REPOSITORY, PROVIDERS, QUERY_BUS
 from .tools import registry_list
 
 # Backward compatibility: expose _parse_args as alias

--- a/mcp_hangar/server/bootstrap.py
+++ b/mcp_hangar/server/bootstrap.py
@@ -28,12 +28,7 @@ from mcp.server.fastmcp import FastMCP
 
 from ..application.commands import register_all_handlers as register_command_handlers
 from ..application.discovery import DiscoveryConfig, DiscoveryOrchestrator
-from ..application.event_handlers import (
-    AlertEventHandler,
-    AuditEventHandler,
-    LoggingEventHandler,
-    MetricsEventHandler,
-)
+from ..application.event_handlers import AlertEventHandler, AuditEventHandler, LoggingEventHandler, MetricsEventHandler
 from ..application.queries import register_all_handlers as register_query_handlers
 from ..application.sagas import GroupRebalanceSaga
 from ..domain.contracts.event_store import NullEventStore

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Quick Start: getting-started/quickstart.md
   - Architecture:
       - Overview: architecture/OVERVIEW.md
+      - Event Sourcing: architecture/EVENT_SOURCING.md
       - ADRs:
           - ADR-001 Langfuse Integration: adr/001-langfuse-integration.md
   - Guides:

--- a/monitoring/grafana/provisioning/datasources/datasources.yaml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yaml
@@ -8,4 +8,3 @@ datasources:
     isDefault: true
     editable: false
     uid: prometheus
-

--- a/monitoring/prometheus/alerts.yaml
+++ b/monitoring/prometheus/alerts.yaml
@@ -114,4 +114,3 @@ groups:
           severity: warning
         annotations:
           summary: "High retry exhaustion for {{ $labels.provider }}/{{ $labels.tool }}"
-

--- a/scripts/containers.sh
+++ b/scripts/containers.sh
@@ -101,4 +101,3 @@ case "$1" in
         exit 1
         ;;
 esac
-

--- a/tests/feature/test_descriptions.py
+++ b/tests/feature/test_descriptions.py
@@ -13,9 +13,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from mcp_hangar.application.queries import (  # noqa: E402
-    register_all_handlers as register_query_handlers,
-)
+from mcp_hangar.application.queries import register_all_handlers as register_query_handlers  # noqa: E402
 from mcp_hangar.server import (  # noqa: E402
     load_config,
     load_config_from_file,

--- a/tests/integration/containers/test_langfuse.py
+++ b/tests/integration/containers/test_langfuse.py
@@ -30,9 +30,7 @@ class TestLangfuseTraceCreation:
         langfuse_container: dict,
     ) -> None:
         """Traces are created and visible in Langfuse API."""
-        from mcp_hangar.infrastructure.observability.langfuse_adapter import (
-            LangfuseObservabilityAdapter,
-        )
+        from mcp_hangar.infrastructure.observability.langfuse_adapter import LangfuseObservabilityAdapter
 
         adapter = LangfuseObservabilityAdapter(langfuse_config)
 
@@ -66,9 +64,7 @@ class TestLangfuseTraceCreation:
         langfuse_config,
     ) -> None:
         """Error traces are recorded without raising exceptions."""
-        from mcp_hangar.infrastructure.observability.langfuse_adapter import (
-            LangfuseObservabilityAdapter,
-        )
+        from mcp_hangar.infrastructure.observability.langfuse_adapter import LangfuseObservabilityAdapter
 
         adapter = LangfuseObservabilityAdapter(langfuse_config)
 
@@ -89,9 +85,7 @@ class TestLangfuseTraceCreation:
     ) -> None:
         """Trace context is properly propagated."""
         from mcp_hangar.application.ports.observability import TraceContext
-        from mcp_hangar.infrastructure.observability.langfuse_adapter import (
-            LangfuseObservabilityAdapter,
-        )
+        from mcp_hangar.infrastructure.observability.langfuse_adapter import LangfuseObservabilityAdapter
 
         adapter = LangfuseObservabilityAdapter(langfuse_config)
 
@@ -121,9 +115,7 @@ class TestLangfuseScoreAndHealthRecording:
         langfuse_config,
     ) -> None:
         """Multiple scores can be recorded on traces."""
-        from mcp_hangar.infrastructure.observability.langfuse_adapter import (
-            LangfuseObservabilityAdapter,
-        )
+        from mcp_hangar.infrastructure.observability.langfuse_adapter import LangfuseObservabilityAdapter
 
         adapter = LangfuseObservabilityAdapter(langfuse_config)
 
@@ -141,9 +133,7 @@ class TestLangfuseScoreAndHealthRecording:
         langfuse_config,
     ) -> None:
         """Health checks are recorded as standalone traces."""
-        from mcp_hangar.infrastructure.observability.langfuse_adapter import (
-            LangfuseObservabilityAdapter,
-        )
+        from mcp_hangar.infrastructure.observability.langfuse_adapter import LangfuseObservabilityAdapter
 
         adapter = LangfuseObservabilityAdapter(langfuse_config)
 
@@ -175,9 +165,7 @@ class TestLangfuseHighVolume:
         """High volume concurrent trace creation is thread-safe."""
         import threading
 
-        from mcp_hangar.infrastructure.observability.langfuse_adapter import (
-            LangfuseObservabilityAdapter,
-        )
+        from mcp_hangar.infrastructure.observability.langfuse_adapter import LangfuseObservabilityAdapter
 
         adapter = LangfuseObservabilityAdapter(langfuse_config)
         errors: list[Exception] = []

--- a/tests/integration/containers/test_postgres.py
+++ b/tests/integration/containers/test_postgres.py
@@ -193,7 +193,7 @@ class TestPostgresAuditLog:
             # Query by time range
             rows = await conn.fetch(
                 """
-                SELECT * FROM audit_log 
+                SELECT * FROM audit_log
                 WHERE created_at > $1
                 ORDER BY created_at DESC
             """,

--- a/tests/integration/test_discovery_integration.py
+++ b/tests/integration/test_discovery_integration.py
@@ -111,11 +111,7 @@ async def run_conflict_resolver():
     """Test ConflictResolver."""
     print_header("Test 2: Conflict Resolver")
 
-    from mcp_hangar.domain.discovery import (
-        ConflictResolution,
-        ConflictResolver,
-        DiscoveredProvider,
-    )
+    from mcp_hangar.domain.discovery import ConflictResolution, ConflictResolver, DiscoveredProvider
 
     # Test static always wins
     resolver = ConflictResolver(static_providers={"my-static-provider"})
@@ -232,12 +228,7 @@ async def run_discovery_service():
     """Test DiscoveryService."""
     print_header("Test 4: Discovery Service")
 
-    from mcp_hangar.domain.discovery import (
-        DiscoveredProvider,
-        DiscoveryMode,
-        DiscoveryService,
-        DiscoverySource,
-    )
+    from mcp_hangar.domain.discovery import DiscoveredProvider, DiscoveryMode, DiscoveryService, DiscoverySource
 
     # Create mock source
     class MockSource(DiscoverySource):
@@ -365,11 +356,7 @@ async def run_security_validator():
     """Test SecurityValidator."""
     print_header("Test 6: Security Validator")
 
-    from mcp_hangar.application.discovery import (
-        SecurityConfig,
-        SecurityValidator,
-        ValidationResult,
-    )
+    from mcp_hangar.application.discovery import SecurityConfig, SecurityValidator, ValidationResult
     from mcp_hangar.domain.discovery import DiscoveredProvider
 
     # Create validator with namespace restrictions

--- a/tests/integration/test_event_sourced_provider.py
+++ b/tests/integration/test_event_sourced_provider.py
@@ -10,10 +10,7 @@ from mcp_hangar.domain.events import (
     ToolInvocationCompleted,
     ToolInvocationFailed,
 )
-from mcp_hangar.domain.model.event_sourced_provider import (
-    EventSourcedProvider,
-    ProviderSnapshot,
-)
+from mcp_hangar.domain.model.event_sourced_provider import EventSourcedProvider, ProviderSnapshot
 from mcp_hangar.domain.model.provider import ProviderState
 
 

--- a/tests/unit/observability/test_langfuse_adapter.py
+++ b/tests/unit/observability/test_langfuse_adapter.py
@@ -15,10 +15,7 @@ import pytest
 if sys.version_info >= (3, 14):
     pytest.skip("Langfuse uses Pydantic v1 which is incompatible with Python 3.14+", allow_module_level=True)
 
-from mcp_hangar.application.ports.observability import (
-    NullSpanHandle,
-    ObservabilityPort,
-)
+from mcp_hangar.application.ports.observability import NullSpanHandle, ObservabilityPort
 from mcp_hangar.infrastructure.observability.langfuse_adapter import (
     LangfuseAdapter,
     LangfuseConfig,

--- a/tests/unit/observability/test_property_based.py
+++ b/tests/unit/observability/test_property_based.py
@@ -9,11 +9,7 @@ import sys
 from hypothesis import given, HealthCheck, settings, strategies as st
 import pytest
 
-from mcp_hangar.application.ports.observability import (
-    NullObservabilityAdapter,
-    NullSpanHandle,
-    TraceContext,
-)
+from mcp_hangar.application.ports.observability import NullObservabilityAdapter, NullSpanHandle, TraceContext
 
 
 class TestTraceContextProperties:

--- a/tests/unit/observability/test_traced_provider_service.py
+++ b/tests/unit/observability/test_traced_provider_service.py
@@ -8,9 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mcp_hangar.application.ports.observability import (
-    NullObservabilityAdapter,
-)
+from mcp_hangar.application.ports.observability import NullObservabilityAdapter
 from mcp_hangar.application.services.traced_provider_service import TracedProviderService
 
 

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -2,11 +2,7 @@
 
 import time
 
-from mcp_hangar.domain.model.circuit_breaker import (
-    CircuitBreaker,
-    CircuitBreakerConfig,
-    CircuitState,
-)
+from mcp_hangar.domain.model.circuit_breaker import CircuitBreaker, CircuitBreakerConfig, CircuitState
 
 
 class TestCircuitBreakerConfig:

--- a/tests/unit/test_command_bus.py
+++ b/tests/unit/test_command_bus.py
@@ -12,11 +12,7 @@ from mcp_hangar.application.commands import (
     StartProviderCommand,
     StopProviderCommand,
 )
-from mcp_hangar.infrastructure.command_bus import (
-    CommandBus,
-    CommandHandler,
-    get_command_bus,
-)
+from mcp_hangar.infrastructure.command_bus import CommandBus, CommandHandler, get_command_bus
 
 
 class TestCommands:

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -4,10 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from mcp_hangar.domain.discovery.conflict_resolver import (
-    ConflictResolution,
-    ConflictResolver,
-)
+from mcp_hangar.domain.discovery.conflict_resolver import ConflictResolution, ConflictResolver
 from mcp_hangar.domain.discovery.discovered_provider import DiscoveredProvider
 from mcp_hangar.domain.discovery.discovery_service import DiscoveryService
 from mcp_hangar.domain.discovery.discovery_source import DiscoveryMode, DiscoverySource

--- a/tests/unit/test_discovery_sources.py
+++ b/tests/unit/test_discovery_sources.py
@@ -22,27 +22,21 @@ class TestDockerDiscoverySource:
 
     def test_source_type(self, mock_docker_client):
         """Test source_type property."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         source = DockerDiscoverySource()
         assert source.source_type == "docker"
 
     def test_default_mode_is_additive(self, mock_docker_client):
         """Test default mode is additive (safe)."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         source = DockerDiscoverySource()
         assert source.mode == DiscoveryMode.ADDITIVE
 
     def test_custom_socket_path(self, mock_docker_client):
         """Test custom socket path."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         source = DockerDiscoverySource(socket_path="/var/run/podman/podman.sock")
         assert source._socket_path == "/var/run/podman/podman.sock"
@@ -50,9 +44,7 @@ class TestDockerDiscoverySource:
     @pytest.mark.asyncio
     async def test_discover_empty(self, mock_docker_client):
         """Test discovery with no containers."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         mock_docker_client.containers.list.return_value = []
 
@@ -64,9 +56,7 @@ class TestDockerDiscoverySource:
     @pytest.mark.asyncio
     async def test_discover_labeled_container(self, mock_docker_client):
         """Test discovery of container with MCP labels."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         # Create mock container with proper return values (not MagicMock)
         mock_container = MagicMock()
@@ -100,9 +90,7 @@ class TestDockerDiscoverySource:
     @pytest.mark.asyncio
     async def test_discover_skips_disabled(self, mock_docker_client):
         """Test discovery skips containers without enabled label."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         mock_container = MagicMock()
         mock_container.name = "test-container"
@@ -122,9 +110,7 @@ class TestDockerDiscoverySource:
     @pytest.mark.asyncio
     async def test_health_check_success(self, mock_docker_client):
         """Test health check when Docker is accessible."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         mock_docker_client.ping.return_value = True
 
@@ -136,9 +122,7 @@ class TestDockerDiscoverySource:
     @pytest.mark.asyncio
     async def test_health_check_failure(self, mock_docker_client):
         """Test health check when Docker is not accessible."""
-        from mcp_hangar.infrastructure.discovery.docker_source import (
-            DockerDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
 
         mock_docker_client.ping.side_effect = Exception("Connection refused")
 
@@ -166,36 +150,28 @@ class TestKubernetesDiscoverySource:
 
     def test_source_type(self, mock_k8s_client):
         """Test source_type property."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         source = KubernetesDiscoverySource(in_cluster=False)
         assert source.source_type == "kubernetes"
 
     def test_default_mode_is_authoritative(self, mock_k8s_client):
         """Test default mode is authoritative for K8s."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         source = KubernetesDiscoverySource(in_cluster=False)
         assert source.mode == DiscoveryMode.AUTHORITATIVE
 
     def test_namespace_filtering(self, mock_k8s_client):
         """Test namespace filtering configuration."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         source = KubernetesDiscoverySource(namespaces=["mcp-providers", "production"], in_cluster=False)
         assert source.namespaces == ["mcp-providers", "production"]
 
     def test_label_selector(self, mock_k8s_client):
         """Test label selector configuration."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         source = KubernetesDiscoverySource(label_selector="app.kubernetes.io/component=mcp-provider", in_cluster=False)
         assert source.label_selector == "app.kubernetes.io/component=mcp-provider"
@@ -203,9 +179,7 @@ class TestKubernetesDiscoverySource:
     @pytest.mark.asyncio
     async def test_discover_empty(self, mock_k8s_client):
         """Test discovery with no pods."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         mock_v1, _ = mock_k8s_client
         mock_pods = MagicMock()
@@ -222,9 +196,7 @@ class TestKubernetesDiscoverySource:
     @pytest.mark.skip(reason="Mock setup complex - discovery logic tested in integration tests")
     async def test_discover_annotated_pod(self, mock_k8s_client):
         """Test discovery of pod with MCP annotations."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         mock_v1, _ = mock_k8s_client
 
@@ -260,9 +232,7 @@ class TestKubernetesDiscoverySource:
     @pytest.mark.asyncio
     async def test_discover_skips_disabled(self, mock_k8s_client):
         """Test discovery skips pods without enabled annotation."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         mock_v1, _ = mock_k8s_client
 
@@ -284,9 +254,7 @@ class TestKubernetesDiscoverySource:
     @pytest.mark.asyncio
     async def test_discover_skips_pod_without_ip(self, mock_k8s_client):
         """Test discovery skips pods without IP (not ready)."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         mock_v1, _ = mock_k8s_client
 
@@ -311,9 +279,7 @@ class TestKubernetesDiscoverySource:
     @pytest.mark.asyncio
     async def test_health_check_success(self, mock_k8s_client):
         """Test health check when K8s API is accessible."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         mock_v1, _ = mock_k8s_client
         mock_v1.get_api_resources.return_value = MagicMock()
@@ -326,9 +292,7 @@ class TestKubernetesDiscoverySource:
     @pytest.mark.asyncio
     async def test_health_check_failure(self, mock_k8s_client):
         """Test health check when K8s API is not accessible."""
-        from mcp_hangar.infrastructure.discovery.kubernetes_source import (
-            KubernetesDiscoverySource,
-        )
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
 
         mock_v1, _ = mock_k8s_client
         mock_v1.get_api_resources.side_effect = Exception("API unavailable")
@@ -344,11 +308,7 @@ class TestDiscoveryMetricsIntegration:
 
     def test_discovery_cycle_metrics(self):
         """Test metrics are recorded for discovery cycle."""
-        from mcp_hangar.metrics import (
-            get_metrics,
-            record_discovery_cycle,
-            update_discovery_source,
-        )
+        from mcp_hangar.metrics import get_metrics, record_discovery_cycle, update_discovery_source
 
         # Record some discovery activity
         update_discovery_source("docker", "additive", True, 3)
@@ -361,11 +321,7 @@ class TestDiscoveryMetricsIntegration:
 
     def test_kubernetes_specific_metrics(self):
         """Test Kubernetes-specific metrics."""
-        from mcp_hangar.metrics import (
-            get_metrics,
-            record_discovery_deregistration,
-            record_discovery_quarantine,
-        )
+        from mcp_hangar.metrics import get_metrics, record_discovery_deregistration, record_discovery_quarantine
 
         # Record K8s-specific events
         record_discovery_deregistration("kubernetes", "ttl_expired")

--- a/tests/unit/test_event_bus_persistence.py
+++ b/tests/unit/test_event_bus_persistence.py
@@ -3,11 +3,7 @@
 import pytest
 
 from mcp_hangar.domain.contracts.event_store import ConcurrencyError
-from mcp_hangar.domain.events import (
-    DomainEvent,
-    ProviderStarted,
-    ProviderStateChanged,
-)
+from mcp_hangar.domain.events import DomainEvent, ProviderStarted, ProviderStateChanged
 from mcp_hangar.infrastructure.event_bus import EventBus
 from mcp_hangar.infrastructure.persistence import InMemoryEventStore
 

--- a/tests/unit/test_event_store.py
+++ b/tests/unit/test_event_store.py
@@ -4,11 +4,7 @@ import tempfile
 
 import pytest
 
-from mcp_hangar.domain.events import (
-    ProviderStarted,
-    ProviderStateChanged,
-    ProviderStopped,
-)
+from mcp_hangar.domain.events import ProviderStarted, ProviderStateChanged, ProviderStopped
 from mcp_hangar.infrastructure.event_store import (
     ConcurrencyError,
     EventStoreSnapshot,

--- a/tests/unit/test_event_store_persistence.py
+++ b/tests/unit/test_event_store_persistence.py
@@ -8,20 +8,9 @@ import threading
 
 import pytest
 
-from mcp_hangar.domain.contracts.event_store import (
-    ConcurrencyError,
-    NullEventStore,
-)
-from mcp_hangar.domain.events import (
-    ProviderStarted,
-    ProviderStateChanged,
-    ProviderStopped,
-    ToolInvocationCompleted,
-)
-from mcp_hangar.infrastructure.persistence import (
-    InMemoryEventStore,
-    SQLiteEventStore,
-)
+from mcp_hangar.domain.contracts.event_store import ConcurrencyError, NullEventStore
+from mcp_hangar.domain.events import ProviderStarted, ProviderStateChanged, ProviderStopped, ToolInvocationCompleted
+from mcp_hangar.infrastructure.persistence import InMemoryEventStore, SQLiteEventStore
 
 
 class TestNullEventStore:

--- a/tests/unit/test_event_upcasting.py
+++ b/tests/unit/test_event_upcasting.py
@@ -1,0 +1,192 @@
+"""Unit tests for event upcasting and versioned event serialization."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import cast
+
+import pytest
+
+from mcp_hangar.domain.events import ProviderStarted
+from mcp_hangar.infrastructure.persistence.event_serializer import EVENT_VERSION_MAP
+from mcp_hangar.infrastructure.persistence.event_upcaster import IEventUpcaster
+from mcp_hangar.infrastructure.persistence import EventSerializer, SQLiteEventStore, UpcasterChain
+
+
+class ProviderStartedV1ToV2(IEventUpcaster):
+    @property
+    def event_type(self) -> str:
+        return "ProviderStarted"
+
+    @property
+    def from_version(self) -> int:
+        return 1
+
+    @property
+    def to_version(self) -> int:
+        return 2
+
+    def upcast(self, data: dict[str, object]) -> dict[str, object]:
+        return {**data, "tags": []}
+
+
+class ProviderStartedV2ToV3(IEventUpcaster):
+    @property
+    def event_type(self) -> str:
+        return "ProviderStarted"
+
+    @property
+    def from_version(self) -> int:
+        return 2
+
+    @property
+    def to_version(self) -> int:
+        return 3
+
+    def upcast(self, data: dict[str, object]) -> dict[str, object]:
+        # Example evolution: rename tools_count -> tools_total
+        tools_count = data.get("tools_count")
+        updated = dict(data)
+        if tools_count is not None:
+            updated["tools_total"] = tools_count
+        return updated
+
+
+def test_upcaster_chain_single_version_jump():
+    chain = UpcasterChain()
+    chain.register(ProviderStartedV1ToV2())
+
+    version, payload = chain.upcast("ProviderStarted", 1, {"provider_id": "x"}, current_version=2)
+
+    assert version == 2
+    assert payload == {"provider_id": "x", "tags": []}
+
+
+def test_upcaster_chain_multi_version_jump():
+    chain = UpcasterChain()
+    chain.register(ProviderStartedV1ToV2())
+    chain.register(ProviderStartedV2ToV3())
+
+    version, payload = chain.upcast("ProviderStarted", 1, {"provider_id": "x", "tools_count": 5}, current_version=3)
+
+    assert version == 3
+    assert payload["provider_id"] == "x"
+    assert payload["tags"] == []
+    assert payload["tools_total"] == 5
+
+
+def test_upcaster_chain_no_upcaster_needed():
+    chain = UpcasterChain()
+
+    version, payload = chain.upcast("ProviderStarted", 3, {"provider_id": "x"}, current_version=3)
+
+    assert version == 3
+    assert payload == {"provider_id": "x"}
+
+
+def test_upcaster_chain_unknown_event_type_passthrough():
+    chain = UpcasterChain()
+
+    version, payload = chain.upcast("SomeUnknownEvent", 1, {"a": 1}, current_version=5)
+
+    assert version == 1
+    assert payload == {"a": 1}
+
+
+def test_serializer_adds_version_on_serialize(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(EVENT_VERSION_MAP, "ProviderStarted", 2)
+
+    serializer = EventSerializer()
+    event = ProviderStarted(provider_id="math", mode="subprocess", tools_count=3, startup_duration_ms=10.0)
+
+    event_type, json_data = serializer.serialize(event)
+
+    assert event_type == "ProviderStarted"
+    payload = json.loads(json_data)
+    assert payload["_version"] == 2
+
+
+def test_serializer_backward_compat_missing_version(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(EVENT_VERSION_MAP, "ProviderStarted", 1)
+
+    serializer = EventSerializer()
+
+    raw_payload = {
+        "provider_id": "math",
+        "mode": "subprocess",
+        "tools_count": 3,
+        "startup_duration_ms": 10.0,
+    }
+
+    event = serializer.deserialize("ProviderStarted", json.dumps(raw_payload))
+
+    assert isinstance(event, ProviderStarted)
+    assert event.provider_id == "math"
+    assert event.tools_count == 3
+
+
+def test_serializer_applies_upcasters_on_deserialize(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(EVENT_VERSION_MAP, "ProviderStarted", 2)
+
+    chain = UpcasterChain()
+    chain.register(ProviderStartedV1ToV2())
+    serializer = EventSerializer(upcaster_chain=chain)
+
+    # Old persisted payload version
+    raw_payload = {
+        "_version": 1,
+        "provider_id": "math",
+        "mode": "subprocess",
+        "tools_count": 3,
+        "startup_duration_ms": 10.0,
+        "tags": [],
+    }
+    # Simulate v1 missing "tags" by removing it
+    raw_payload.pop("tags")
+
+    event = serializer.deserialize("ProviderStarted", json.dumps(raw_payload))
+
+    assert isinstance(event, ProviderStarted)
+    assert event.provider_id == "math"
+
+
+def test_end_to_end_old_event_in_sqlite_store(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(EVENT_VERSION_MAP, "ProviderStarted", 2)
+
+    chain = UpcasterChain()
+    chain.register(ProviderStartedV1ToV2())
+    serializer = EventSerializer(upcaster_chain=chain)
+
+    db_path = tmp_path / "events.db"
+    store = SQLiteEventStore(db_path, serializer=serializer)
+
+    # Insert old event directly (no _version)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        payload = json.dumps(
+            {
+                "provider_id": "math",
+                "mode": "subprocess",
+                "tools_count": 1,
+                "startup_duration_ms": 1.0,
+            }
+        )
+        conn.execute(
+            "INSERT INTO streams (stream_id, version, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            ("provider:math", 0, "2020-01-01T00:00:00Z", "2020-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO events (stream_id, stream_version, event_type, data, created_at) VALUES (?, ?, ?, ?, ?)",
+            ("provider:math", 0, "ProviderStarted", payload, "2020-01-01T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    events = store.read_stream("provider:math")
+
+    assert len(events) == 1
+    assert isinstance(events[0], ProviderStarted)
+    ev = cast(ProviderStarted, events[0])
+    assert ev.provider_id == "math"

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,14 +1,7 @@
 """Tests for domain events and event bus."""
 
-from mcp_hangar.application.event_handlers import (
-    LoggingEventHandler,
-    MetricsEventHandler,
-)
-from mcp_hangar.domain.events import (
-    ProviderStarted,
-    ProviderStopped,
-    ToolInvocationCompleted,
-)
+from mcp_hangar.application.event_handlers import LoggingEventHandler, MetricsEventHandler
+from mcp_hangar.domain.events import ProviderStarted, ProviderStopped, ToolInvocationCompleted
 from mcp_hangar.infrastructure.event_bus import EventBus, get_event_bus, reset_event_bus
 
 

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -11,11 +11,7 @@ import pytest
 
 from mcp_hangar.server.bootstrap import ApplicationContext
 from mcp_hangar.server.cli import CLIConfig
-from mcp_hangar.server.lifecycle import (
-    _setup_signal_handlers,
-    run_server,
-    ServerLifecycle,
-)
+from mcp_hangar.server.lifecycle import _setup_signal_handlers, run_server, ServerLifecycle
 
 
 class TestServerLifecycle:

--- a/tests/unit/test_provider_group.py
+++ b/tests/unit/test_provider_group.py
@@ -4,17 +4,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mcp_hangar.domain.model.provider_group import (
-    GroupCircuitOpened,
-    GroupCreated,
-    GroupMemberAdded,
-    ProviderGroup,
-)
-from mcp_hangar.domain.value_objects import (
-    GroupState,
-    LoadBalancerStrategy,
-    ProviderState,
-)
+from mcp_hangar.domain.model.provider_group import GroupCircuitOpened, GroupCreated, GroupMemberAdded, ProviderGroup
+from mcp_hangar.domain.value_objects import GroupState, LoadBalancerStrategy, ProviderState
 
 
 def create_mock_provider(provider_id: str, state: ProviderState = ProviderState.READY):

--- a/tests/unit/test_recovery_service.py
+++ b/tests/unit/test_recovery_service.py
@@ -2,9 +2,7 @@
 
 import pytest
 
-from mcp_hangar.domain.contracts.persistence import (
-    ProviderConfigSnapshot,
-)
+from mcp_hangar.domain.contracts.persistence import ProviderConfigSnapshot
 from mcp_hangar.domain.repository import InMemoryProviderRepository
 from mcp_hangar.infrastructure.persistence import (
     Database,

--- a/tests/unit/test_saga_manager.py
+++ b/tests/unit/test_saga_manager.py
@@ -2,11 +2,7 @@
 
 from typing import List
 
-from mcp_hangar.application.commands import (
-    Command,
-    StartProviderCommand,
-    StopProviderCommand,
-)
+from mcp_hangar.application.commands import Command, StartProviderCommand, StopProviderCommand
 from mcp_hangar.domain.events import DomainEvent, ProviderDegraded, ProviderStarted
 from mcp_hangar.infrastructure.command_bus import CommandBus, CommandHandler
 from mcp_hangar.infrastructure.event_bus import EventBus

--- a/tests/unit/test_sagas.py
+++ b/tests/unit/test_sagas.py
@@ -3,12 +3,7 @@
 from mcp_hangar.application.commands import StartProviderCommand, StopProviderCommand
 from mcp_hangar.application.sagas.provider_failover_saga import ProviderFailoverSaga
 from mcp_hangar.application.sagas.provider_recovery_saga import ProviderRecoverySaga
-from mcp_hangar.domain.events import (
-    HealthCheckFailed,
-    ProviderDegraded,
-    ProviderStarted,
-    ProviderStopped,
-)
+from mcp_hangar.domain.events import HealthCheckFailed, ProviderDegraded, ProviderStarted, ProviderStopped
 
 
 class TestProviderRecoverySaga:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -36,12 +36,7 @@ from mcp_hangar.domain.security.input_validator import (
     validate_timeout,
     validate_tool_name,
 )
-from mcp_hangar.domain.security.rate_limiter import (
-    InMemoryRateLimiter,
-    RateLimitConfig,
-    RateLimitResult,
-    TokenBucket,
-)
+from mcp_hangar.domain.security.rate_limiter import InMemoryRateLimiter, RateLimitConfig, RateLimitResult, TokenBucket
 from mcp_hangar.domain.security.sanitizer import (
     sanitize_command_argument,
     sanitize_environment_value,

--- a/tests/unit/test_structlog.py
+++ b/tests/unit/test_structlog.py
@@ -14,12 +14,7 @@ from mcp_hangar.context import (
     RequestContextManager,
     update_request_context,
 )
-from mcp_hangar.logging_config import (
-    _add_service_context,
-    _sanitize_sensitive_data,
-    get_logger,
-    setup_logging,
-)
+from mcp_hangar.logging_config import _add_service_context, _sanitize_sensitive_data, get_logger, setup_logging
 
 
 class TestSetupLogging:


### PR DESCRIPTION
This pull request primarily adds a new architecture documentation file describing the event sourcing approach in MCP Hangar, including persistence format, schema versioning, upcasting, and troubleshooting. Additionally, it contains minor cleanup changes across various documentation, workflow, and configuration files, mostly removing trailing blank lines for consistency.

**Major documentation addition:**

* Added `docs/architecture/EVENT_SOURCING.md` to document the event sourcing strategy, JSON persistence format, schema versioning, upcasting rules, upcaster implementation, registration, and troubleshooting for evolving event schemas.

**Minor documentation and configuration cleanups:**

* Removed trailing blank lines from multiple workflow files (e.g., `.github/workflows/docs.yml`, `.github/workflows/release.yml`, `.github/workflows/security.yml`, `.github/workflows/version-bump.yml`). [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL72) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L285) [[3]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL105) [[4]](diffhunk://#diff-e8ca070981ccdc3f369851c960bec6882143a0c7afe78acd7b05e0c2b0068d72L147)
* Removed trailing blank lines from various documentation and example files for formatting consistency (e.g., `README.md`, `docs/adr/001-langfuse-integration.md`, `docs/architecture/OVERVIEW.md`, `docs/guides/CONTAINERS.md`, `docs/guides/DISCOVERY.md`, `docs/guides/TESTING.md`, `docs/runbooks/RELEASE.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L296) [[2]](diffhunk://#diff-24ce20894f7848db035f1377c092aeb8fb340e6b49d6b741167996e0592759dbL114) [[3]](diffhunk://#diff-aaef4aa7ced1454b1dba0a738f98a16d0cc8c9d7e832367d1dd884b574485f44L165) [[4]](diffhunk://#diff-a718609c769a5050aae9a60e8a15198866fd921e24912b9f641ad079746ac1ecL167) [[5]](diffhunk://#diff-96d2d122939dc173999ccd3032da7cdfedd65f6fd4c630e6da89e0fccb0c08e4L165) [[6]](diffhunk://#diff-70bc220fa58572a95301b4b143a6dbf5c459924bba424d92ed5703e5a51844ecL231) [[7]](diffhunk://#diff-dff0fe86ad6626dc8c3f22febd4b1497c05ba74f9580549124bb1b72017c6548L274)
* Removed trailing blank lines from example configuration files (e.g., Dockerfiles, docker-compose files, Kubernetes manifests, provider YAMLs). [[1]](diffhunk://#diff-c645bec33a6bb89ee8addbe1e94c5b1f7d332bf638f2328ba5d6e90c09113151L65) [[2]](diffhunk://#diff-e25a5c419ba949d8f35097669d46a477dd48d8330e3373a91c4ae028408df83cL41) [[3]](diffhunk://#diff-bcd972e6372e0087d1600779b6224d79bfde0426611d13fd330fa57c796ad707L51) [[4]](diffhunk://#diff-51259e09b37c5468a8dab72cc52e1c3cc905ef9f8293eb1cc2fc92892eb43261L178) [[5]](diffhunk://#diff-135d437bd5a30208847e2c3675053744a7cc8b26fad3c3d9d049329fdf6abd9eL19) [[6]](diffhunk://#diff-18fcd410691fecd1e404d06544909f67cea922cc514b4007a979211edf8b273aL22)
* Removed trailing blank line from `docker/Dockerfile.sqlite` for consistency.