### PR TITLE
fix(ci): fix crlf parsing and relax commitlint subject-case

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -14,8 +14,8 @@ rules:
     - never
   subject-case:
     - 2
-    - always
-    - [lower-case, sentence-case]
+    - never
+    - [upper-case]
   subject-full-stop:
     - 2
     - never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Export Formats (B-11)**: Three new enterprise compliance exporters implementing `IAuditExporter`: `JSONLinesExporter` (one JSON object per line), `LEEFExporter` (IBM QRadar LEEF 2.0), `SyslogExporter` (RFC 5424 structured data). All support file, callback, or stderr output.
 - **Agent Behavior Scoring (B-04)**: `RiskScore` value object, `IRiskScorer` contract with `WeightedRiskScorer` implementation using exponential time decay (configurable half-life). `RiskScoringEventHandler` subscribes to `BehavioralDeviationDetected`, `DetectionRuleMatched`, and `CapabilityViolationDetected` events to aggregate per-server and per-session anomaly scores.
 
+### Fixed
+
+- PR body validator: handle CRLF line endings in event payload (was reporting all sections empty)
+- commitlint: relax subject-case rule to allow file references and acronyms (was blocking any commit mentioning CHANGELOG.md, MCP, OAuth, etc.)
+- GIT_FLOW.md: add `repo` to approved CC scopes for root-level governance files
+
 ## [1.0.2] - 2026-04-24
 
 ### Changed

--- a/docs/development/GIT_FLOW.md
+++ b/docs/development/GIT_FLOW.md
@@ -78,6 +78,7 @@ They are used in commit messages: `<type>(<scope>): <subject>`.
 | docs | Markdown documentation and MkDocs config |
 | deps | Dependency updates and lockfile changes |
 | release | Release artifacts and versioning |
+| repo | Root-level governance files: AGENTS.md, CODEOWNERS, LICENSE, commitlint config |
 | infra | Dockerfile, Makefile, and local dev setup |
 | tests | Test fixtures and suite configuration |
 

--- a/scripts/check_pr_body.sh
+++ b/scripts/check_pr_body.sh
@@ -9,7 +9,7 @@ if echo "$PR_LABELS" | grep -q "trivial"; then
   exit 0
 fi
 
-stripped=$(echo "$PR_BODY" | sed 's/<!--.*-->//g' | sed '/<!--/,/-->/d')
+stripped=$(echo "$PR_BODY" | tr -d '\r' | sed 's/<!--.*-->//g' | sed '/<!--/,/-->/d')
 
 required_sections=("## Why" "## What" "## How tested" "## Risk and rollback" "## CHANGELOG note")
 failed=false


### PR DESCRIPTION
This pull request makes several improvements to developer workflow and project documentation. The main changes include fixing the PR body validator to handle CRLF line endings, relaxing the commit message subject-case rule to allow acronyms and file references, and updating documentation to clarify commit scopes.

Bug fixes:

* PR body validator now handles CRLF line endings in event payloads, preventing false reports of empty sections (`scripts/check_pr_body.sh`).

Commit linting and workflow improvements:

* The `subject-case` rule in `.commitlintrc.yml` is relaxed to allow upper-case subjects, accommodating acronyms and file references in commit messages (`.commitlintrc.yml`).
* Added `repo` to the list of approved commit scopes for root-level governance files in `GIT_FLOW.md` (`docs/development/GIT_FLOW.md`).

Documentation updates:

* The changelog documents these fixes and improvements for better project transparency (`CHANGELOG.md`).