### PR TITLE
ci(release): add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Why
Release-please currently triggers only on push:main. Adding workflow_dispatch enables manual reruns when needed (e.g., after permission changes, config edits) without needing a no-op commit. Refs #69 follow-up.

## What
- Add workflow_dispatch trigger to .github/workflows/release-please.yml

## How tested
- actionlint .github/workflows/release-please.yml — clean (1-line YAML add, no logic change)
- After merge: gh workflow run release-please.yml succeeds (was 422 "no workflow_dispatch trigger")

## Risk and rollback
Trivial. Workflow logic unchanged. Revert: single line removal.

## CHANGELOG note
skip-changelog: workflow tooling change, no triggering path modified