### PR TITLE
ci(release): use GitHub App token for release-please to trigger required checks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,7 +14,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why
GITHUB_TOKEN-created PRs do not trigger downstream pull_request workflows by GitHub design. This blocks release-please PRs from running our required checks (pr-title, commitlint, pr-body, changelog), making them unmergeable without a manual close+reopen dance. Switching to a GitHub App token means release-please PRs are created by the App identity, which DOES trigger workflows. Refs #69 follow-up.

## What
- Add actions/create-github-app-token@v1 step that mints a short-lived App token using RELEASE_BOT_APP_ID and RELEASE_BOT_PRIVATE_KEY secrets
- Pass the generated token to release-please-action via the token input
- Add workflow_dispatch trigger for manual invocation when needed

## How tested
- actionlint .github/workflows/release-please.yml — clean (post-merge verification)
- Post-merge: gh workflow run release-please.yml triggers the App-authenticated run; resulting Release PR has all required checks attached and shows mcp-hangar-release-bot[bot] as author

## Risk and rollback
Low. If the App token step fails, the entire workflow fails (no partial state). Rollback: revert the commit; release-please falls back to GITHUB_TOKEN behavior.

## CHANGELOG note
skip-changelog: workflow tooling change, no triggering path modified