### PR TITLE
fix(ci): skip editable installs in pip-audit to avoid self-lookup

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run pip-audit
         run: |
           pip install -e .
-          pip-audit --strict --desc on
+          pip-audit --skip-editable --strict --desc on
 
       - name: Run safety check
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR body validator: handle CRLF line endings in event payload (was reporting all sections empty)
 - commitlint: relax subject-case rule to allow file references and acronyms (was blocking any commit mentioning CHANGELOG.md, MCP, OAuth, etc.)
 - GIT_FLOW.md: add `repo` to approved CC scopes for root-level governance files
+- pip-audit `--skip-editable` to prevent circular self-lookup on Release PRs
 
 ### Removed
 


### PR DESCRIPTION
This pull request makes a minor update to the security workflow to improve the reliability of dependency auditing during release pull requests.

* Security workflow improvement:
  * [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL37-R37): Added the `--skip-editable` flag to the `pip-audit` command to prevent circular self-lookup issues when running audits on editable installs, especially during Release PRs.
  * [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24): Documented the addition of the `--skip-editable` flag to `pip-audit` for improved audit stability.## Why
<!-- 1-3 sentences on motivation. Link to issue: Closes #N or Refs #N -->

## What
<!-- Bulleted list of changes. Imperative voice. -->

-

## How tested
<!-- Commands run, scenarios verified. "Manual smoke on X" is acceptable.
     For UI changes: include browser/screenshot.
     For workflows: actionlint output. -->

## Risk and rollback
<!-- What could break and how to revert.
     "Low risk; revert single commit" is fine for trivial changes. -->

## CHANGELOG note
<!-- Paste the [Unreleased] entry this PR adds, or write: skip-changelog: <reason> -->

## Agent metadata
<!-- Fill if this PR was authored by a coding agent (Copilot, Claude, etc.).
     Humans: delete this entire section if not applicable. -->
- [ ] Single Conventional Commit scope: `<scope>`
- [ ] Single goal (no scope creep)
- [ ] LOC declared upfront: `<n>`
- [ ] Files in scope match the issue brief
