### PR TITLE
chore(release): override release-please pr title pattern with release…

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,7 @@
       "include-component-in-tag": false,
       "tag-separator": "",
       "extra-files": [],
+      "pull-request-title-pattern": "chore(release): release ${version}",
       "changelog-sections": [
         { "type": "feat",     "section": "Added",      "hidden": false },
         { "type": "fix",      "section": "Fixed",      "hidden": false },


### PR DESCRIPTION
This pull request introduces a configuration update to the release automation. The main change is setting a consistent pull request title pattern for release PRs.

- Release automation configuration:
  * Added the `pull-request-title-pattern` property to the `release-please-config.json` file to standardize release PR titles as `chore(release): release ${version}`.