### PR TITLE
chore(docs): exclude changelog from markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+docs/changelog.md


### PR DESCRIPTION
This pull request adds two files, `CHANGELOG.md` and `docs/changelog.md`, to the `.markdownlintignore` file so that they are excluded from markdown linting.