### PR TITLE
fix(docs): use glob exclusion for changelog in markdownlint workflow

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -31,7 +31,8 @@ jobs:
           globs: |
             docs/**/*.md
             *.md
-            *.md
+            !CHANGELOG.md
+            !docs/changelog.md
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small update to the documentation workflow configuration. The change ensures that the CI job excludes `CHANGELOG.md` and `docs/changelog.md` files from its glob pattern, so changes to these files will not trigger the workflow.