### PR TITLE
fix(ci): drop strict flag from pip-audit to allow skip-editable

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run pip-audit
         run: |
           pip install -e .
-          pip-audit --skip-editable --strict --desc on
+          pip-audit --skip-editable --desc on
 
       - name: Run safety check
         run: |


### PR DESCRIPTION
This pull request makes a minor change to the security workflow configuration. The `--strict` flag was removed from the `pip-audit` command in the `.github/workflows/security.yml` file, likely to reduce audit failures or warnings.