### PR TITLE
ci(infra): add branch-name validator workflow

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,0 +1,39 @@
+# Enforces branch naming per GIT_FLOW.md section "Branch naming and merge strategy".
+name: branch-name
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          # Tool prefixes pass without restriction
+          if [[ "$BRANCH" =~ ^(dependabot|copilot)/ ]] || [[ "$BRANCH" =~ ^release-please-- ]]; then
+            echo "::notice::Branch name '$BRANCH' is a recognized tool prefix."
+            exit 0
+          fi
+          # Standard CC-typed branches
+          if [[ "$BRANCH" =~ ^(feat|fix|perf|refactor|docs|test|build|ci|chore)/[a-z][a-z0-9-]*$ ]]; then
+            echo "::notice::Branch name '$BRANCH' is valid."
+            exit 0
+          fi
+          # Hotfix: hotfix/vX.Y.Z
+          if [[ "$BRANCH" =~ ^hotfix/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::notice::Branch name '$BRANCH' is a valid hotfix."
+            exit 0
+          fi
+          echo "::error::Branch name '$BRANCH' does not match GIT_FLOW.md conventions."
+          echo "Expected: <type>/<slug> where type is feat|fix|perf|refactor|docs|test|build|ci|chore."
+          echo "Or: hotfix/vX.Y.Z, dependabot/*, copilot/*, release-please--*."
+          echo "See: https://github.com/mcp-hangar/mcp-hangar/blob/main/docs/development/GIT_FLOW.md#branch-naming-and-merge-strategy"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Branch name validator workflow enforcing GIT_FLOW.md naming conventions on PRs
+
 ## [1.0.3](https://github.com/mcp-hangar/mcp-hangar/compare/v1.0.2...v1.0.3) (2026-05-10)
 
 

--- a/docs/development/BRANCH_PROTECTION.md
+++ b/docs/development/BRANCH_PROTECTION.md
@@ -12,6 +12,7 @@ Branch protection on `main` ensures that every commit landing in the default bra
   - `pr-title / validate`
   - `commitlint / lint`
   - `changelog / check`
+  - `branch-name / validate`
   - `pr-body / validate`
 - Required approving reviewers: 0
 - Require code owner reviews: false
@@ -31,6 +32,7 @@ Branch protection on `main` ensures that every commit landing in the default bra
 | `pr-title / validate` | `pr-title.yml` | Conventional Commits title |
 | `commitlint / lint` | `commitlint.yml` | Per-commit message lint |
 | `changelog / check` | `changelog-check.yml` | CHANGELOG entry present |
+| `branch-name / validate` | `branch-name.yml` | Branch naming convention |
 | `pr-body / validate` | `pr-body.yml` | PR body section structure |
 
 ## Solo vs community mode

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -42,6 +42,7 @@ PAYLOAD=$(cat <<EOF
       "pr-title / validate",
       "commitlint / lint",
       "changelog / check",
+      "branch-name / validate",
       "pr-body / validate"
     ]
   },


### PR DESCRIPTION
## Why

Last enforcement gap from Wave A. GIT_FLOW.md documents branch naming conventions but nothing validates them in CI. PRs can land with arbitrary branch names.

## What

- Add `.github/workflows/branch-name.yml` that validates `github.head_ref` against allowed prefixes
- Register `branch-name / validate` as a required status check in `setup-branch-protection.sh`
- Update `BRANCH_PROTECTION.md` with the new check entry
- CHANGELOG entry under `[Unreleased] > Added`

## How tested

- `bash -n` syntax check on `setup-branch-protection.sh`
- `bash scripts/setup-branch-protection.sh --dry-run` produces valid JSON with the new check
- Workflow regex manually verified against valid names (feat/foo, fix/bar, hotfix/v1.0.0, dependabot/npm, copilot/task, release-please--branches--main) and invalid names (my-feature, FEAT/foo, feat/, feat/FOO)

## Risk and rollback

Low risk. New workflow only, no changes to existing checks. Rollback: delete `.github/workflows/branch-name.yml` and remove the check from `setup-branch-protection.sh`.

## CHANGELOG note

Added: Branch name validator workflow enforcing GIT_FLOW.md naming conventions on PRs.

Closes #94