### PR TITLE
chore(infra): add gh project v2 board with issue and pr automation

### DIFF
--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -1,0 +1,19 @@
+name: Project Add
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/mcp-hangar/projects/${{ vars.PROJECT_NUMBER }}
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Branch name validator workflow enforcing GIT_FLOW.md naming conventions on PRs
+- GitHub Projects v2 board setup script and auto-add workflow
 
 ## [1.0.3](https://github.com/mcp-hangar/mcp-hangar/compare/v1.0.2...v1.0.3) (2026-05-10)
 

--- a/docs/development/PROJECT_BOARD.md
+++ b/docs/development/PROJECT_BOARD.md
@@ -1,0 +1,72 @@
+# Project Board
+
+## Overview
+
+The MCP Hangar project uses a GitHub Projects v2 board for issue triage and lifecycle tracking.
+
+Board URL: `https://github.com/orgs/mcp-hangar/projects/<N>` (set after first run of setup script).
+
+## Custom fields
+
+| Field | Type | Values |
+|---|---|---|
+| Priority | Single select | p0-critical, p1-high, p2-normal, p3-low |
+| Scope | Single select | core, enterprise, cli, operator, helm, ui, observability, security, docs, deps, release, infra, tests, repo |
+| Target Release | Text | Freeform, e.g. `1.1.0` |
+| Estimate (LOC) | Number | Rough size hint |
+
+## Status flow
+
+```
+Triage -> Backlog -> Ready -> In Progress -> In Review -> Done
+                                  \-> Blocked -/
+```
+
+- **Triage**: newly opened issues land here.
+- **Backlog**: accepted but not yet scheduled.
+- **Ready**: scheduled for current cycle.
+- **In Progress**: actively being worked on.
+- **In Review**: PR open, awaiting review.
+- **Blocked**: waiting on external dependency.
+- **Done**: merged or closed.
+
+## Built-in Project workflows
+
+Configure these in the Project UI (Settings > Workflows):
+
+1. **Item closed**: set Status = Done.
+2. **Pull request merged**: set Status = Done.
+
+The `.github/workflows/project-add.yml` workflow handles auto-adding new issues and PRs. The built-in workflows above handle status transitions.
+
+## Token setup
+
+The `project-add.yml` workflow requires a `PROJECT_AUTOMATION_TOKEN` secret and a `PROJECT_NUMBER` repository variable.
+
+### Option A: Extend the release-bot App (recommended)
+
+1. Go to the `mcp-hangar-release-bot` GitHub App settings.
+2. Add `Organization > Projects: Read & write` permission.
+3. Generate an installation token and store it as `PROJECT_AUTOMATION_TOKEN` in repository secrets.
+
+### Option B: Fine-grained PAT
+
+1. Create a fine-grained PAT scoped to the `mcp-hangar` org with `project: write`.
+2. Store as `PROJECT_AUTOMATION_TOKEN` in repository secrets.
+
+Do not use classic PATs scoped to a user account.
+
+## Setup script
+
+```bash
+bash scripts/setup-gh-project.sh
+OWNER=mcp-hangar PROJECT_TITLE="MCP Hangar" bash scripts/setup-gh-project.sh
+```
+
+The script is idempotent. Re-runs are no-ops for existing fields. Status field options must be configured manually in the Project UI (the gh CLI does not support modifying built-in field options).
+
+After the first run, set the `PROJECT_NUMBER` repository variable:
+
+```bash
+gh variable set PROJECT_NUMBER --body "<N>"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - Branch Protection: development/BRANCH_PROTECTION.md
       - Hotfix Runbook: development/HOTFIX_RUNBOOK.md
       - Epic Playbook: development/EPIC_PLAYBOOK.md
+      - Project Board: development/PROJECT_BOARD.md
       - Release Process: runbooks/RELEASE.md
       - Contributor License Agreement: cla.md
   - Reference:

--- a/scripts/setup-gh-project.sh
+++ b/scripts/setup-gh-project.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OWNER="${OWNER:-mcp-hangar}"
+PROJECT_TITLE="${PROJECT_TITLE:-MCP Hangar}"
+
+project_number=$(
+  gh project list --owner "$OWNER" --format json \
+    | python3 -c "
+import json, sys
+for p in json.load(sys.stdin).get('projects', []):
+    if p.get('title') == '$PROJECT_TITLE':
+        print(p['number'])
+        sys.exit(0)
+" 2>/dev/null || true
+)
+
+if [ -z "$project_number" ]; then
+  echo "Creating project '$PROJECT_TITLE' under $OWNER..."
+  project_number=$(
+    gh project create --owner "$OWNER" --title "$PROJECT_TITLE" --format json \
+      | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])"
+  )
+  echo "Created project #$project_number."
+else
+  echo "Project '$PROJECT_TITLE' already exists (#$project_number)."
+fi
+
+existing_fields=$(
+  gh project field-list "$project_number" --owner "$OWNER" --format json
+)
+
+field_exists() {
+  echo "$existing_fields" \
+    | python3 -c "
+import json, sys
+for f in json.load(sys.stdin).get('fields', []):
+    if f.get('name') == sys.argv[1]:
+        sys.exit(0)
+sys.exit(1)
+" "$1"
+}
+
+if ! field_exists "Priority"; then
+  echo "Creating field: Priority"
+  gh project field-create "$project_number" --owner "$OWNER" \
+    --name "Priority" --data-type "SINGLE_SELECT" \
+    --single-select-options "p0-critical,p1-high,p2-normal,p3-low"
+else
+  echo "Field 'Priority' already exists."
+fi
+
+if ! field_exists "Scope"; then
+  echo "Creating field: Scope"
+  gh project field-create "$project_number" --owner "$OWNER" \
+    --name "Scope" --data-type "SINGLE_SELECT" \
+    --single-select-options "core,enterprise,cli,operator,helm,ui,observability,security,docs,deps,release,infra,tests,repo"
+else
+  echo "Field 'Scope' already exists."
+fi
+
+if ! field_exists "Target Release"; then
+  echo "Creating field: Target Release"
+  gh project field-create "$project_number" --owner "$OWNER" \
+    --name "Target Release" --data-type "TEXT"
+else
+  echo "Field 'Target Release' already exists."
+fi
+
+if ! field_exists "Estimate (LOC)"; then
+  echo "Creating field: Estimate (LOC)"
+  gh project field-create "$project_number" --owner "$OWNER" \
+    --name "Estimate (LOC)" --data-type "NUMBER"
+else
+  echo "Field 'Estimate (LOC)' already exists."
+fi
+
+echo ""
+echo "NOTE: Status field options (Triage, Backlog, Ready, In Progress, In Review,"
+echo "Blocked, Done) must be configured manually in the Project UI."
+echo "The gh CLI does not support modifying built-in field options."
+echo "See docs/development/PROJECT_BOARD.md for instructions."
+
+echo ""
+echo "Project #$project_number setup complete."
+echo "URL: https://github.com/orgs/$OWNER/projects/$project_number"
+echo ""
+echo "Final state:"
+gh project field-list "$project_number" --owner "$OWNER"


### PR DESCRIPTION
## Why

Issue list is chronologically flat. A GitHub Projects v2 board provides visual triage, lifecycle tracking, and custom field filtering before issue volume grows. This is the last infra gap from the Wave A setup.

## What

- `scripts/setup-gh-project.sh` (89 LOC) -- idempotent script creating the project and custom fields (Priority, Scope, Target Release, Estimate)
- `.github/workflows/project-add.yml` (19 LOC) -- auto-adds new issues and PRs to the board via `actions/add-to-project@v1`
- `docs/development/PROJECT_BOARD.md` (72 lines) -- runbook covering custom fields, status flow, built-in workflow config, and token setup
- `mkdocs.yml` nav entry for the runbook
- CHANGELOG entry

## How tested

- `bash -n scripts/setup-gh-project.sh` -- syntax OK
- `mkdocs.yml` YAML validation -- valid
- Script LOC (89) within 120 limit, workflow LOC (19) within 40 limit, runbook (72) within 80 limit
- Status field note: built-in field options require manual UI config (gh CLI limitation); script prints a reminder and runbook documents the steps

## Risk and rollback

Low risk. New files only, no changes to existing workflows. Rollback: delete the three new files and revert the mkdocs nav line.

## CHANGELOG note

Added: GitHub Projects v2 board setup script and auto-add workflow.

Closes #96