### PR TITLE
chore(release): sign release artifacts with sigstore via github oidc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,8 @@ jobs:
       name: ${{ needs.validate.outputs.is_prerelease == 'true' && 'testpypi' || 'pypi' }}
       url: ${{ needs.validate.outputs.is_prerelease == 'true' && 'https://test.pypi.org/p/mcp-hangar' || 'https://pypi.org/p/mcp-hangar' }}
     permissions:
-      id-token: write  # Required for trusted publishing
+      id-token: write  # Required for trusted publishing and OIDC signing
+      attestations: write  # Required for build provenance attestations
 
     steps:
       - uses: actions/checkout@v4
@@ -178,6 +179,11 @@ jobs:
 
       - name: Build package
         run: python -m build
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'dist/*'
 
       - name: Verify package
         run: |
@@ -206,6 +212,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -232,6 +239,7 @@ jobs:
             type=raw,value=latest,enable=${{ needs.validate.outputs.is_prerelease == 'false' }}
 
       - name: Build and push Docker image
+        id: docker-build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -242,6 +250,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign container image
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images="${images} ${tag}@${DIGEST}"
+          done
+          cosign sign --yes ${images}
 
   # Create GitHub Release with changelog
   create-release:


### PR DESCRIPTION
## Why

GIT_FLOW.md decision #4 left artifact signing as soft mode due to lack of a stable signing environment. Sigstore (cosign + GitHub OIDC) eliminates that constraint: signing happens in CI using ephemeral identity tokens, no private keys involved.

## What

- `publish-pypi` job: added `attestations: write` permission and `actions/attest-build-provenance@v2` step after `python -m build` to produce SLSA build attestations for wheel and sdist
- `publish-docker` job: added `id-token: write` permission, `sigstore/cosign-installer@v3`, and `cosign sign --yes` step to keylessly sign GHCR images after push

## How tested

Workflow syntax verified via diff review. Actual verification requires a release (`v1.1.0` or later):

```bash
gh attestation verify <wheel-file> --owner mcp-hangar

cosign verify ghcr.io/mcp-hangar/mcp-hangar:VERSION \
  --certificate-identity-regexp '^https://github.com/mcp-hangar/mcp-hangar/.github/workflows/release.yml@.*' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
```

## Risk and rollback

Low risk. Additive steps only -- existing build and publish steps unchanged. If signing fails, the release fails (intentional per issue constraints -- no `continue-on-error`). Rollback: revert the 3 new steps and permission additions.

## CHANGELOG note

Added: Sigstore build provenance attestations for PyPI artifacts and cosign keyless signatures for GHCR container images.

Closes #95