### PR TITLE
fix(ci): bump actions/add-to-project from v1 to v2

### DIFF
--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -13,7 +13,7 @@ jobs:
   add:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/orgs/mcp-hangar/projects/${{ vars.PROJECT_NUMBER }}
           github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Why

`actions/add-to-project@v1` major tag does not exist -- only specific point releases (v1.0.0-v1.0.2) and the `v2` major tag. The project-add workflow fails immediately on every PR and issue open event.

## What

Bump `actions/add-to-project` from `@v1` to `@v2` in `.github/workflows/project-add.yml`.

## How tested

Verified available tags via `gh api repos/actions/add-to-project/tags` -- `v2` is the only major version alias. Will validate on this PR's own workflow run.

## Risk and rollback

No risk. One-line version bump. Rollback: revert to a pinned point release (e.g. `@v1.0.2`).

## CHANGELOG note

Trivial CI fix, no changelog entry needed.