### PR TITLE
ci(infra): add commit-msg pre-commit hook for local cc enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,15 @@ repos:
         pass_filenames: false
         files: ^src/mcp_hangar/.*\.py$
 
+  # Commitlint - enforce Conventional Commits locally on commit-msg stage
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.18.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies:
+          - "@commitlint/config-conventional"
+
   # Pytest check (optional - runs fast tests)
   # Uncomment if you want tests to run on commit
   # - repo: local

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -145,6 +145,7 @@ See [Git Flow](GIT_FLOW.md) for branching conventions, merge strategy, and commi
 4. Run checks:
 
    ```bash
+   pre-commit install --hook-type pre-commit --hook-type commit-msg
    pytest -v -m "not slow"
    pre-commit run --all-files
    ```


### PR DESCRIPTION
## Why

Local CC enforcement closes the feedback loop at commit time -- invalid subjects are rejected before push, saving a CI round-trip. Reuses `.commitlintrc.yml` as single source of truth.

Closes #102

## What

- Add `commit-msg` stage hook (`alessandrojcm/commitlint-pre-commit-hook` v9.18.0) to `.pre-commit-config.yaml`
- Add `pre-commit install --hook-type commit-msg` instruction to `docs/development/CONTRIBUTING.md`

## How tested

- YAML validated via `yaml.safe_load` (passes)
- Hook config matches documented schema for `alessandrojcm/commitlint-pre-commit-hook`
- `stages: [commit-msg]` isolates from `pre-commit run --all-files` runs

## Risk and rollback

Low risk; revert single commit. Hook is opt-in (requires `pre-commit install --hook-type commit-msg`).

## CHANGELOG note

skip-changelog: chore/ci tooling, no user-facing change

## Agent metadata

- [x] Single Conventional Commit scope: `infra`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `10`
- [x] Files in scope match the issue brief