### PR TITLE
ci(infra): add concurrency control to pr-triggered workflows

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -17,6 +17,10 @@ on:
       - "pyproject.toml"
       - ".github/workflows/ci-core.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RUFF_VERSION: "0.14.13"
 

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -17,6 +17,10 @@ on:
       - '.markdownlint.json'
       - '.github/workflows/ci-docs.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Markdown Lint

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -11,6 +11,10 @@ on:
       - 'packages/helm-charts/**'
       - '.github/workflows/ci-helm.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-operator.yml
+++ b/.github/workflows/ci-operator.yml
@@ -11,6 +11,10 @@ on:
       - 'packages/operator/**'
       - '.github/workflows/ci-operator.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: packages/operator

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,6 +4,10 @@ name: Dependabot auto-merge
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,10 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-audit:
     name: Dependency Audit


### PR DESCRIPTION
## Why

Multiple pushes to a PR (force-push, rebase, follow-up commits) re-run all workflows from scratch even though prior runs are stale. This wastes Actions minutes and delays feedback. Adding `concurrency:` blocks ensures only the latest run per PR ref completes; older ones are cancelled.

Closes #103

## What

- Add top-level `concurrency:` block to all 13 PR-triggered workflows
- Group: `${{ github.workflow }}-${{ github.ref }}` (per-workflow, per-PR isolation)
- `cancel-in-progress: true` cancels stale runs

Files modified:
`branch-name.yml`, `changelog-check.yml`, `ci-core.yml`, `ci-docs.yml`, `ci-helm.yml`, `ci-operator.yml`, `commitlint.yml`, `dependabot-automerge.yml`, `pr-body.yml`, `pr-title.yml`, `pr-validation.yml`, `project-add.yml`, `security.yml`

Files NOT touched (out of scope): `release.yml`, `release-please.yml`, `stale.yml`, `labels-sync.yml`

## How tested

- All 13 files YAML-validated via `yaml.safe_load` (12/13 pass; `pr-title.yml` has pre-existing regex parse issue on line 55 unrelated to this change)
- `actionlint` not available locally; CI will validate on push
- Concurrency block structure verified programmatically (all 13 files contain `concurrency.group` and `concurrency.cancel-in-progress`)

## Risk and rollback

Low risk; revert single commit. Concurrency is purely additive -- same triggers, same job logic, only stale-run cancellation is new.

## CHANGELOG note

skip-changelog: ci tooling, no user-facing change

## Agent metadata

- [x] Single Conventional Commit scope: `infra`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `52` (4 lines x 13 files)
- [x] Files in scope match the issue brief