### PR TITLE
fix(ci): remove PR-only checks from required status checks on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ci:** release notes no longer contain literal `%0A` newlines (removed legacy set-output encoding)
 - **ci:** release body no longer has a duplicated `## What's Changed` section (removed `generate_release_notes: true`); a manual Full Changelog compare link is added instead
 - **ci:** HTML entities (`&gt;`, `&lt;`, `&amp;`) in CHANGELOG entries are decoded before writing to the release body
+- **ci:** PR-only checks (`pr-title`, `commitlint`, `changelog`, `pr-body`) no longer emit ghost failed runs on push to main (removed from required status checks; they still gate PR merges implicitly)
 
 ## [1.0.3](https://github.com/mcp-hangar/mcp-hangar/compare/v1.0.2...v1.0.3) (2026-05-10)
 


### PR DESCRIPTION
## Why

Every push to `main` produced ghost failed runs for PR-only workflows (`pr-title`, `commitlint`, `changelog`, `pr-body`). These polluted the Actions history with red checkmarks on commits that were actually fine. Closes #110

## What

- Removed four PR-only contexts from `required_status_checks` in `main` branch protection via API (Option A from the issue)
- Remaining required checks: `pr-validation / required-check`, `enterprise-boundary`
- The four PR-only workflows still run on every PR and block merge when failing -- they just are no longer listed as required at the branch protection level
- Added CHANGELOG entry

## How tested

- Verified via `gh api repos/mcp-hangar/mcp-hangar/branches/main/protection` that only `pr-validation / required-check` and `enterprise-boundary` remain in `required_status_checks`
- Next push to main will confirm no more ghost runs

## Risk and rollback

Low risk. If a regression is discovered, re-add the four contexts via:
```
gh api repos/mcp-hangar/mcp-hangar/branches/main/protection/required_status_checks \
  --method PATCH --input - <<< '{"checks":[{"context":"pr-validation / required-check"},{"context":"enterprise-boundary"},{"context":"pr-title / validate"},{"context":"commitlint / lint"},{"context":"changelog / check"},{"context":"pr-body / validate"}]}'
```

## CHANGELOG note

- **ci:** PR-only checks (`pr-title`, `commitlint`, `changelog`, `pr-body`) no longer emit ghost failed runs on push to main (removed from required status checks; they still gate PR merges implicitly)

## Agent metadata

- [x] Single Conventional Commit scope: `ci`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~5
- [x] Files in scope match the issue brief