### PR TITLE
feat(ci): add actionlint workflow to validate workflow YAML

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,29 @@
+# Validates GitHub Actions workflow YAML. See GIT_FLOW.md automation surface.
+name: actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  schedule:
+    - cron: '0 6 * * 1'   # Monday 06:00 UTC, drift catcher
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End-to-end observability and compliance loop: cost attribution in audit spans, risk score normalization and emission, compliance exporter deprecation rename, dynamic enterprise bootstrap (#106)
 - Branch name validator workflow enforcing GIT_FLOW.md naming conventions on PRs
 - GitHub Projects v2 board setup script and auto-add workflow
+- actionlint CI workflow to validate `.github/workflows/` YAML on PRs, push to main, and weekly schedule (#111)
 
 ### Fixed
 


### PR DESCRIPTION
## Why

The repository has 16 workflow files under `.github/workflows/` and no static validator. Recent defects (#109) that slipped through review would have been caught by actionlint. Closes #111

## What

- Add `.github/workflows/actionlint.yml` running `rhysd/actionlint` on:
  - PRs touching `.github/workflows/**`
  - Push to `main` (same paths)
  - Weekly Monday 06:00 UTC schedule (drift catcher)
  - Manual `workflow_dispatch`
- Add CHANGELOG entry under `[Unreleased] > Added`

## How tested

- Ran `actionlint` locally against all 16 workflow files
- One pre-existing finding (not fixed in this PR): `pr-title.yml:55` -- unquoted regex containing `:` in YAML context

## Risk and rollback

Low risk; new additive workflow. Revert single commit to remove. Pre-existing actionlint finding in `pr-title.yml` may cause the first run to fail -- address in a follow-up PR.

## CHANGELOG note

- actionlint CI workflow to validate `.github/workflows/` YAML on PRs, push to main, and weekly schedule (#111)

## Agent metadata

- [x] Single Conventional Commit scope: `ci`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~30
- [x] Files in scope match the issue brief