### PR TITLE
security(ci): scope dependabot-automerge pull_request_target to main

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,6 +3,8 @@ name: Dependabot auto-merge
 
 on:
   pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ci:** release body no longer has a duplicated `## What's Changed` section (removed `generate_release_notes: true`); a manual Full Changelog compare link is added instead
 - **ci:** HTML entities (`&gt;`, `&lt;`, `&amp;`) in CHANGELOG entries are decoded before writing to the release body
 
+### Security
+
+- **ci:** scope `dependabot-automerge` `pull_request_target` to `branches: [main]` with explicit event types (#112)
+
 ## [1.0.3](https://github.com/mcp-hangar/mcp-hangar/compare/v1.0.2...v1.0.3) (2026-05-10)
 
 


### PR DESCRIPTION
## Why

`dependabot-automerge.yml` uses `pull_request_target` -- a privileged trigger that runs with target repo secrets -- without a `branches:` filter. After the release-please rollout the repo regularly has long-lived `release-please--*` branches; a misconfigured dependabot PR retargeted to one of those would inherit secrets unnecessarily. Defense in depth. Closes #112

## What

- Add `branches: [main]` to `pull_request_target` trigger
- Add explicit `types: [opened, synchronize, reopened, ready_for_review]` (previously unfiltered, firing on all 15+ PR event types)
- Existing `github.actor == 'dependabot[bot]'` guard unchanged
- Add CHANGELOG entry under `[Unreleased] > Security`

## How tested

- Verified YAML syntax locally
- Auto-merge logic (the `if`/`elif` decision tree) is untouched -- no behavioral regression possible
- A dependabot PR targeting a non-main branch will no longer trigger this workflow (cannot test without a real retargeted PR; documented in issue)

## Risk and rollback

Low risk; revert single commit. The only behavioral change is that the workflow no longer fires on PRs targeting non-main branches (which should not exist for dependabot anyway).

## CHANGELOG note

- **ci:** scope `dependabot-automerge` `pull_request_target` to `branches: [main]` with explicit event types (#112)

## Agent metadata

- [x] Single Conventional Commit scope: `ci`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~3
- [x] Files in scope match the issue brief