### PR TITLE
feat(core): add ADR-004 digest pinning domain types and standalone validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Branch name validator workflow enforcing GIT_FLOW.md naming conventions on PRs
 - GitHub Projects v2 board setup script and auto-add workflow
 - actionlint CI workflow to validate `.github/workflows/` YAML on PRs, push to main, and weekly schedule (#111)
+- **core:** ADR-004 digest pinning domain types (`ToolDigest`, `DigestPolicy`, `DigestMismatchEvent`), canonical SHA-256 computation helper, and standalone `DigestValidator` service (#119)
 
 ### Fixed
 

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1479,6 +1479,35 @@ class CapabilityDeclarationMissing(DomainEvent):
         super().__init__()
 
 
+@dataclass
+class DigestMismatchEvent(DomainEvent):
+    """Published when a tool's observed digest does not match the expected digest.
+
+    Emitted by the digest validator during tool invocation or tool list refresh.
+    The enforcement field records what action was taken (audit/warn/block).
+
+    Attributes:
+        mcp_server_id: McpServer that served the tool.
+        tool_name: Name of the tool with mismatched digest.
+        expected_digest: The digest from the allowlist, or None if tool had no entry.
+        observed_digest: The computed digest of the tool's current schema.
+        enforcement: The DigestEnforcement value applied.
+        correlation_id: Request correlation ID for audit trail linkage.
+        schema_version: Event schema version.
+    """
+
+    mcp_server_id: str
+    tool_name: str
+    expected_digest: str | None
+    observed_digest: str | None
+    enforcement: str
+    correlation_id: str
+    schema_version: int = 1
+
+    def __post_init__(self):
+        super().__init__()
+
+
 # ---------------------------------------------------------------------------
 # Behavioral Profiling Events
 # ---------------------------------------------------------------------------

--- a/src/mcp_hangar/domain/services/digest_computation.py
+++ b/src/mcp_hangar/domain/services/digest_computation.py
@@ -1,0 +1,54 @@
+"""Digest computation for MCP tool schemas (SEP-1766).
+
+Produces deterministic SHA-256 fingerprints from tool schema dicts,
+enabling drift detection and allowlist-based pinning.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from mcp_hangar.domain.value_objects.tool_digest import ToolDigest
+
+
+def compute_tool_digest(tool: dict[str, Any]) -> ToolDigest:
+    """Compute the canonical SHA-256 digest of a tool schema.
+
+    Canonical form: JSON with sorted keys, no whitespace separators,
+    and only the fields {name, description, inputSchema, outputSchema}.
+    Fields that are None/missing are omitted from the canonical payload.
+
+    Args:
+        tool: Tool schema dict as returned by MCP tools/list.
+              Expected keys: name, description, inputSchema, outputSchema.
+
+    Returns:
+        ToolDigest with the computed sha256 hex string.
+
+    Raises:
+        ValueError: If tool has no 'name' key.
+    """
+    name = tool.get("name")
+    if not name:
+        raise ValueError("tool dict must contain a non-empty 'name' key")
+
+    canonical_payload: dict[str, Any] = {"name": name}
+
+    description = tool.get("description")
+    if description is not None:
+        canonical_payload["description"] = description
+
+    input_schema = tool.get("inputSchema")
+    if input_schema is not None:
+        canonical_payload["inputSchema"] = input_schema
+
+    output_schema = tool.get("outputSchema")
+    if output_schema is not None:
+        canonical_payload["outputSchema"] = output_schema
+
+    serialized = json.dumps(canonical_payload, sort_keys=True, separators=(",", ":"))
+    sha256_hex = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+    return ToolDigest(tool_name=name, sha256=sha256_hex)

--- a/src/mcp_hangar/domain/services/digest_validator.py
+++ b/src/mcp_hangar/domain/services/digest_validator.py
@@ -1,0 +1,135 @@
+"""Standalone digest validator for non-cloud mode (SEP-1766).
+
+Validates tool digests against an in-process allowlist defined by DigestPolicy.
+Produces DigestMismatchEvent when observed digest differs from expected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcp_hangar.domain.events import DigestMismatchEvent
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.domain.value_objects.tool_digest import (
+    DigestEnforcement,
+    DigestPolicy,
+    DigestUnknownPolicy,
+)
+
+
+@dataclass(frozen=True)
+class DigestValidationResult:
+    """Result of validating a single tool's digest against the policy."""
+
+    tool_name: str
+    valid: bool
+    blocked: bool
+    event: DigestMismatchEvent | None
+
+
+class DigestValidator:
+    """Validates tool digests against a DigestPolicy allowlist.
+
+    Stateless service: instantiate with a policy, call validate_tool() per tool.
+    Emits DigestMismatchEvent objects for each mismatch (caller publishes them).
+    """
+
+    def __init__(self, policy: DigestPolicy) -> None:
+        self._policy = policy
+
+    @property
+    def policy(self) -> DigestPolicy:
+        return self._policy
+
+    def validate_tool(
+        self,
+        tool: dict[str, Any],
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> DigestValidationResult:
+        """Validate a single tool schema against the digest policy.
+
+        Args:
+            tool: Tool schema dict (from tools/list response).
+            mcp_server_id: Identifier of the MCP server providing the tool.
+            correlation_id: Request correlation ID for audit trail.
+
+        Returns:
+            DigestValidationResult with validation outcome and optional event.
+        """
+        observed = compute_tool_digest(tool)
+        expected = self._policy.get_expected_digest(observed.tool_name)
+
+        if expected is None:
+            return self._handle_unknown_tool(observed.tool_name, observed.sha256, mcp_server_id, correlation_id)
+
+        if expected.sha256 == observed.sha256:
+            return DigestValidationResult(tool_name=observed.tool_name, valid=True, blocked=False, event=None)
+
+        return self._handle_mismatch(
+            tool_name=observed.tool_name,
+            expected_digest=expected.sha256,
+            observed_digest=observed.sha256,
+            mcp_server_id=mcp_server_id,
+            correlation_id=correlation_id,
+        )
+
+    def validate_tool_list(
+        self,
+        tools: list[dict[str, Any]],
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> list[DigestValidationResult]:
+        """Validate all tools from a tools/list response.
+
+        Returns a list of results, one per tool. Only tools with issues
+        will have event != None.
+        """
+        return [self.validate_tool(tool, mcp_server_id, correlation_id) for tool in tools]
+
+    def _handle_unknown_tool(
+        self,
+        tool_name: str,
+        observed_digest: str,
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> DigestValidationResult:
+        unknown_policy = self._policy.unknown
+
+        if unknown_policy == DigestUnknownPolicy.ALLOW_DEGRADED:
+            return DigestValidationResult(tool_name=tool_name, valid=True, blocked=False, event=None)
+
+        event = DigestMismatchEvent(
+            mcp_server_id=mcp_server_id,
+            tool_name=tool_name,
+            expected_digest=None,
+            observed_digest=observed_digest,
+            enforcement=unknown_policy.value,
+            correlation_id=correlation_id,
+        )
+
+        blocked = unknown_policy == DigestUnknownPolicy.BLOCK
+        return DigestValidationResult(tool_name=tool_name, valid=False, blocked=blocked, event=event)
+
+    def _handle_mismatch(
+        self,
+        tool_name: str,
+        expected_digest: str,
+        observed_digest: str,
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> DigestValidationResult:
+        enforcement = self._policy.enforcement
+
+        event = DigestMismatchEvent(
+            mcp_server_id=mcp_server_id,
+            tool_name=tool_name,
+            expected_digest=expected_digest,
+            observed_digest=observed_digest,
+            enforcement=enforcement.value,
+            correlation_id=correlation_id,
+        )
+
+        blocked = enforcement == DigestEnforcement.BLOCK
+        return DigestValidationResult(tool_name=tool_name, valid=False, blocked=blocked, event=event)

--- a/src/mcp_hangar/domain/value_objects/__init__.py
+++ b/src/mcp_hangar/domain/value_objects/__init__.py
@@ -79,6 +79,9 @@ from .discovery import DiscoverySourceSpec
 # License
 from .license import LicenseTier
 
+# Tool Digest (SEP-1766)
+from .tool_digest import DigestEnforcement, DigestPolicy, DigestUnknownPolicy, ToolDigest
+
 __all__ = [
     # Security
     "PrincipalType",
@@ -140,6 +143,11 @@ __all__ = [
     "ToolCapabilities",
     "ViolationSeverity",
     "ViolationType",
+    # Tool Digest
+    "ToolDigest",
+    "DigestEnforcement",
+    "DigestUnknownPolicy",
+    "DigestPolicy",
 ]
 
 import sys

--- a/src/mcp_hangar/domain/value_objects/tool_digest.py
+++ b/src/mcp_hangar/domain/value_objects/tool_digest.py
@@ -1,0 +1,86 @@
+"""Tool digest value objects for SEP-1766 digest pinning.
+
+Provides immutable domain primitives for tool integrity verification:
+- ToolDigest: SHA-256 fingerprint of a tool's canonical schema
+- DigestEnforcement: enforcement level on mismatch (audit/warn/block)
+- DigestUnknownPolicy: handling of tools without a known digest
+- DigestPolicy: combines enforcement, unknown-tool handling, and an allowlist
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+_HEX64_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class DigestEnforcement(StrEnum):
+    """Enforcement level when a tool digest mismatch is detected."""
+
+    AUDIT = "audit"
+    WARN = "warn"
+    BLOCK = "block"
+
+
+class DigestUnknownPolicy(StrEnum):
+    """How to handle tools that have no digest in the allowlist."""
+
+    ALLOW_DEGRADED = "allow_degraded"
+    WARN = "warn"
+    BLOCK = "block"
+
+
+@dataclass(frozen=True)
+class ToolDigest:
+    """SHA-256 fingerprint of a tool's canonical schema.
+
+    Attributes:
+        tool_name: Fully qualified tool name.
+        sha256: 64-character lowercase hex SHA-256 digest.
+        algorithm: Hash algorithm identifier (forward-compat for spec changes).
+    """
+
+    tool_name: str
+    sha256: str
+    algorithm: str = "sha256"
+
+    def __post_init__(self):
+        if not self.tool_name:
+            raise ValueError("tool_name cannot be empty")
+        if not _HEX64_PATTERN.match(self.sha256):
+            raise ValueError("sha256 must be exactly 64 lowercase hex characters")
+        if not self.algorithm:
+            raise ValueError("algorithm cannot be empty")
+
+
+@dataclass(frozen=True)
+class DigestPolicy:
+    """Policy governing tool digest enforcement.
+
+    Attributes:
+        enforcement: What to do when a digest mismatch is detected.
+        unknown: What to do when a tool has no known digest in the allowlist.
+        allowlist: Set of approved tool digests.
+    """
+
+    enforcement: DigestEnforcement
+    unknown: DigestUnknownPolicy
+    allowlist: frozenset[ToolDigest]
+
+    def __post_init__(self):
+        if not isinstance(self.enforcement, DigestEnforcement):
+            raise TypeError("enforcement must be a DigestEnforcement value")
+        if not isinstance(self.unknown, DigestUnknownPolicy):
+            raise TypeError("unknown must be a DigestUnknownPolicy value")
+        if not isinstance(self.allowlist, frozenset):
+            raise TypeError("allowlist must be a frozenset of ToolDigest")
+
+    def get_expected_digest(self, tool_name: str) -> ToolDigest | None:
+        """Look up the expected digest for a tool by name."""
+        for digest in self.allowlist:
+            if digest.tool_name == tool_name:
+                return digest
+        return None

--- a/tests/unit/domain/services/test_digest_computation.py
+++ b/tests/unit/domain/services/test_digest_computation.py
@@ -1,0 +1,115 @@
+"""Unit tests for digest computation helper."""
+
+import json
+import hashlib
+
+import pytest
+
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.domain.value_objects.tool_digest import ToolDigest
+
+
+class TestComputeToolDigest:
+    """compute_tool_digest canonical hashing behavior."""
+
+    @pytest.fixture
+    def sample_tool(self):
+        return {
+            "name": "read_file",
+            "description": "Read a file from disk",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        }
+
+    def test_returns_tool_digest(self, sample_tool):
+        result = compute_tool_digest(sample_tool)
+        assert isinstance(result, ToolDigest)
+        assert result.tool_name == "read_file"
+        assert result.algorithm == "sha256"
+        assert len(result.sha256) == 64
+
+    def test_deterministic(self, sample_tool):
+        d1 = compute_tool_digest(sample_tool)
+        d2 = compute_tool_digest(sample_tool)
+        assert d1.sha256 == d2.sha256
+
+    def test_key_order_independent(self, sample_tool):
+        reordered = {
+            "inputSchema": sample_tool["inputSchema"],
+            "description": sample_tool["description"],
+            "name": sample_tool["name"],
+        }
+        assert compute_tool_digest(sample_tool).sha256 == compute_tool_digest(reordered).sha256
+
+    def test_nested_key_order_independent(self):
+        tool_a = {
+            "name": "t",
+            "inputSchema": {"properties": {"a": {"type": "string"}, "b": {"type": "int"}}, "type": "object"},
+        }
+        tool_b = {
+            "name": "t",
+            "inputSchema": {"type": "object", "properties": {"b": {"type": "int"}, "a": {"type": "string"}}},
+        }
+        assert compute_tool_digest(tool_a).sha256 == compute_tool_digest(tool_b).sha256
+
+    def test_different_description_different_digest(self, sample_tool):
+        modified = {**sample_tool, "description": "DIFFERENT"}
+        assert compute_tool_digest(sample_tool).sha256 != compute_tool_digest(modified).sha256
+
+    def test_different_schema_different_digest(self, sample_tool):
+        modified = {**sample_tool, "inputSchema": {"type": "string"}}
+        assert compute_tool_digest(sample_tool).sha256 != compute_tool_digest(modified).sha256
+
+    def test_different_name_different_digest(self, sample_tool):
+        modified = {**sample_tool, "name": "write_file"}
+        assert compute_tool_digest(sample_tool).sha256 != compute_tool_digest(modified).sha256
+
+    def test_output_schema_included_when_present(self, sample_tool):
+        with_output = {**sample_tool, "outputSchema": {"type": "string"}}
+        without_output = sample_tool
+        assert compute_tool_digest(with_output).sha256 != compute_tool_digest(without_output).sha256
+
+    def test_output_schema_none_omitted(self, sample_tool):
+        with_none = {**sample_tool, "outputSchema": None}
+        without = sample_tool
+        assert compute_tool_digest(with_none).sha256 == compute_tool_digest(without).sha256
+
+    def test_extra_fields_ignored(self, sample_tool):
+        with_extra = {**sample_tool, "annotations": {"readOnly": True}, "extra_field": "ignored"}
+        assert compute_tool_digest(sample_tool).sha256 == compute_tool_digest(with_extra).sha256
+
+    def test_missing_description_omitted(self):
+        tool = {"name": "minimal", "inputSchema": {"type": "object"}}
+        tool_with_none = {"name": "minimal", "description": None, "inputSchema": {"type": "object"}}
+        result = compute_tool_digest(tool)
+        assert result.tool_name == "minimal"
+        assert len(result.sha256) == 64
+        # None description = missing description (both omitted from canonical)
+        assert compute_tool_digest(tool).sha256 == compute_tool_digest(tool_with_none).sha256
+
+    def test_empty_name_raises(self):
+        with pytest.raises(ValueError, match="non-empty 'name'"):
+            compute_tool_digest({"name": "", "inputSchema": {}})
+
+    def test_missing_name_raises(self):
+        with pytest.raises(ValueError, match="non-empty 'name'"):
+            compute_tool_digest({"description": "no name"})
+
+    def test_canonical_form_matches_manual_computation(self):
+        tool = {"name": "t", "description": "d", "inputSchema": {"type": "object"}}
+        expected_payload = {"description": "d", "inputSchema": {"type": "object"}, "name": "t"}
+        expected_json = json.dumps(expected_payload, sort_keys=True, separators=(",", ":"))
+        expected_hash = hashlib.sha256(expected_json.encode("utf-8")).hexdigest()
+        assert compute_tool_digest(tool).sha256 == expected_hash
+
+    def test_unicode_in_description(self):
+        tool = {"name": "t", "description": "Przetwarzanie danych"}
+        result = compute_tool_digest(tool)
+        assert len(result.sha256) == 64
+
+    def test_empty_input_schema(self):
+        tool = {"name": "t", "inputSchema": {}}
+        result = compute_tool_digest(tool)
+        assert len(result.sha256) == 64

--- a/tests/unit/domain/services/test_digest_validator.py
+++ b/tests/unit/domain/services/test_digest_validator.py
@@ -1,0 +1,219 @@
+"""Unit tests for DigestValidator domain service."""
+
+import pytest
+
+from mcp_hangar.domain.events import DigestMismatchEvent
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.domain.services.digest_validator import DigestValidator
+from mcp_hangar.domain.value_objects.tool_digest import (
+    DigestEnforcement,
+    DigestPolicy,
+    DigestUnknownPolicy,
+)
+
+
+@pytest.fixture
+def known_tool():
+    return {
+        "name": "read_file",
+        "description": "Read a file",
+        "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}},
+    }
+
+
+@pytest.fixture
+def known_digest(known_tool):
+    return compute_tool_digest(known_tool)
+
+
+@pytest.fixture
+def block_policy(known_digest):
+    return DigestPolicy(
+        enforcement=DigestEnforcement.BLOCK,
+        unknown=DigestUnknownPolicy.WARN,
+        allowlist=frozenset([known_digest]),
+    )
+
+
+@pytest.fixture
+def audit_policy(known_digest):
+    return DigestPolicy(
+        enforcement=DigestEnforcement.AUDIT,
+        unknown=DigestUnknownPolicy.ALLOW_DEGRADED,
+        allowlist=frozenset([known_digest]),
+    )
+
+
+class TestDigestValidatorMatchingDigest:
+    """Behavior when observed digest matches the allowlist."""
+
+    def test_valid_result(self, block_policy, known_tool):
+        validator = DigestValidator(block_policy)
+        result = validator.validate_tool(known_tool, "srv1", "corr-1")
+        assert result.valid is True
+        assert result.blocked is False
+        assert result.event is None
+
+    def test_valid_with_audit_policy(self, audit_policy, known_tool):
+        validator = DigestValidator(audit_policy)
+        result = validator.validate_tool(known_tool, "srv1", "corr-1")
+        assert result.valid is True
+        assert result.blocked is False
+        assert result.event is None
+
+
+class TestDigestValidatorMismatch:
+    """Behavior when observed digest does not match the allowlist."""
+
+    def test_block_enforcement(self, block_policy, known_tool):
+        modified_tool = {**known_tool, "description": "TAMPERED"}
+        validator = DigestValidator(block_policy)
+        result = validator.validate_tool(modified_tool, "srv1", "corr-2")
+        assert result.valid is False
+        assert result.blocked is True
+        assert result.event is not None
+        assert result.event.enforcement == "block"
+        assert result.event.tool_name == "read_file"
+        assert result.event.mcp_server_id == "srv1"
+        assert result.event.correlation_id == "corr-2"
+        assert result.event.expected_digest is not None
+        assert result.event.observed_digest is not None
+        assert result.event.expected_digest != result.event.observed_digest
+
+    def test_audit_enforcement_not_blocked(self, known_tool, known_digest):
+        policy = DigestPolicy(
+            enforcement=DigestEnforcement.AUDIT,
+            unknown=DigestUnknownPolicy.WARN,
+            allowlist=frozenset([known_digest]),
+        )
+        modified_tool = {**known_tool, "description": "TAMPERED"}
+        validator = DigestValidator(policy)
+        result = validator.validate_tool(modified_tool, "srv1", "corr-3")
+        assert result.valid is False
+        assert result.blocked is False
+        assert result.event is not None
+        assert result.event.enforcement == "audit"
+
+    def test_warn_enforcement_not_blocked(self, known_tool, known_digest):
+        policy = DigestPolicy(
+            enforcement=DigestEnforcement.WARN,
+            unknown=DigestUnknownPolicy.WARN,
+            allowlist=frozenset([known_digest]),
+        )
+        modified_tool = {**known_tool, "description": "TAMPERED"}
+        validator = DigestValidator(policy)
+        result = validator.validate_tool(modified_tool, "srv1", "corr-4")
+        assert result.valid is False
+        assert result.blocked is False
+        assert result.event is not None
+        assert result.event.enforcement == "warn"
+
+    def test_event_is_digest_mismatch_event(self, block_policy, known_tool):
+        modified_tool = {**known_tool, "description": "X"}
+        validator = DigestValidator(block_policy)
+        result = validator.validate_tool(modified_tool, "srv1", "corr-5")
+        assert isinstance(result.event, DigestMismatchEvent)
+
+
+class TestDigestValidatorUnknownTool:
+    """Behavior when tool is not in the allowlist at all."""
+
+    @pytest.fixture
+    def unknown_tool(self):
+        return {"name": "new_tool", "description": "unknown", "inputSchema": {}}
+
+    def test_unknown_warn_not_blocked(self, block_policy, unknown_tool):
+        validator = DigestValidator(block_policy)
+        result = validator.validate_tool(unknown_tool, "srv1", "corr-6")
+        assert result.valid is False
+        assert result.blocked is False
+        assert result.event is not None
+        assert result.event.expected_digest is None
+        assert result.event.observed_digest is not None
+        assert result.event.enforcement == "warn"
+
+    def test_unknown_block_is_blocked(self, known_digest, unknown_tool):
+        policy = DigestPolicy(
+            enforcement=DigestEnforcement.AUDIT,
+            unknown=DigestUnknownPolicy.BLOCK,
+            allowlist=frozenset([known_digest]),
+        )
+        validator = DigestValidator(policy)
+        result = validator.validate_tool(unknown_tool, "srv1", "corr-7")
+        assert result.valid is False
+        assert result.blocked is True
+        assert result.event is not None
+        assert result.event.enforcement == "block"
+
+    def test_unknown_allow_degraded_passes(self, audit_policy, unknown_tool):
+        validator = DigestValidator(audit_policy)
+        result = validator.validate_tool(unknown_tool, "srv1", "corr-8")
+        assert result.valid is True
+        assert result.blocked is False
+        assert result.event is None
+
+
+class TestDigestValidatorToolList:
+    """validate_tool_list batch behavior."""
+
+    def test_mixed_results(self, block_policy, known_tool):
+        modified_tool = {**known_tool, "description": "TAMPERED"}
+        unknown_tool = {"name": "new", "description": "x", "inputSchema": {}}
+        validator = DigestValidator(block_policy)
+
+        results = validator.validate_tool_list([known_tool, modified_tool, unknown_tool], "srv1", "corr-9")
+
+        assert len(results) == 3
+        assert results[0].valid is True
+        assert results[1].valid is False
+        assert results[1].blocked is True
+        assert results[2].valid is False
+        assert results[2].blocked is False
+
+    def test_empty_list(self, block_policy):
+        validator = DigestValidator(block_policy)
+        results = validator.validate_tool_list([], "srv1", "corr-10")
+        assert results == []
+
+    def test_all_valid(self, block_policy, known_tool):
+        validator = DigestValidator(block_policy)
+        results = validator.validate_tool_list([known_tool, known_tool], "srv1", "corr-11")
+        assert all(r.valid for r in results)
+
+
+class TestDigestValidatorEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_policy_property(self, block_policy):
+        validator = DigestValidator(block_policy)
+        assert validator.policy is block_policy
+
+    def test_empty_allowlist_all_unknown(self):
+        policy = DigestPolicy(
+            enforcement=DigestEnforcement.BLOCK,
+            unknown=DigestUnknownPolicy.BLOCK,
+            allowlist=frozenset(),
+        )
+        validator = DigestValidator(policy)
+        tool = {"name": "any_tool", "inputSchema": {}}
+        result = validator.validate_tool(tool, "srv1", "corr-12")
+        assert result.valid is False
+        assert result.blocked is True
+
+    def test_tool_with_output_schema(self, known_digest):
+        tool_with_output = {
+            "name": "read_file",
+            "description": "Read a file",
+            "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}},
+            "outputSchema": {"type": "string"},
+        }
+        policy = DigestPolicy(
+            enforcement=DigestEnforcement.BLOCK,
+            unknown=DigestUnknownPolicy.WARN,
+            allowlist=frozenset([known_digest]),
+        )
+        validator = DigestValidator(policy)
+        result = validator.validate_tool(tool_with_output, "srv1", "corr-13")
+        # Adding outputSchema changes digest -> mismatch
+        assert result.valid is False
+        assert result.blocked is True

--- a/tests/unit/domain/value_objects/test_tool_digest.py
+++ b/tests/unit/domain/value_objects/test_tool_digest.py
@@ -1,0 +1,190 @@
+"""Unit tests for ToolDigest and DigestPolicy value objects."""
+
+import pytest
+
+from mcp_hangar.domain.value_objects.tool_digest import (
+    DigestEnforcement,
+    DigestPolicy,
+    DigestUnknownPolicy,
+    ToolDigest,
+)
+
+
+class TestToolDigest:
+    """ToolDigest value object validation and behavior."""
+
+    def test_valid_digest(self):
+        td = ToolDigest(tool_name="read_file", sha256="a" * 64)
+        assert td.tool_name == "read_file"
+        assert td.sha256 == "a" * 64
+        assert td.algorithm == "sha256"
+
+    def test_custom_algorithm(self):
+        td = ToolDigest(tool_name="x", sha256="b" * 64, algorithm="sha256-v2")
+        assert td.algorithm == "sha256-v2"
+
+    def test_frozen_immutability(self):
+        td = ToolDigest(tool_name="x", sha256="c" * 64)
+        with pytest.raises(AttributeError):
+            td.tool_name = "y"  # type: ignore[misc]
+
+    def test_rejects_empty_tool_name(self):
+        with pytest.raises(ValueError, match="tool_name cannot be empty"):
+            ToolDigest(tool_name="", sha256="a" * 64)
+
+    def test_rejects_short_hash(self):
+        with pytest.raises(ValueError, match="64 lowercase hex"):
+            ToolDigest(tool_name="x", sha256="abc")
+
+    def test_rejects_uppercase_hash(self):
+        with pytest.raises(ValueError, match="64 lowercase hex"):
+            ToolDigest(tool_name="x", sha256="A" * 64)
+
+    def test_rejects_non_hex_characters(self):
+        with pytest.raises(ValueError, match="64 lowercase hex"):
+            ToolDigest(tool_name="x", sha256="g" * 64)
+
+    def test_rejects_65_char_hash(self):
+        with pytest.raises(ValueError, match="64 lowercase hex"):
+            ToolDigest(tool_name="x", sha256="a" * 65)
+
+    def test_rejects_63_char_hash(self):
+        with pytest.raises(ValueError, match="64 lowercase hex"):
+            ToolDigest(tool_name="x", sha256="a" * 63)
+
+    def test_rejects_empty_algorithm(self):
+        with pytest.raises(ValueError, match="algorithm cannot be empty"):
+            ToolDigest(tool_name="x", sha256="a" * 64, algorithm="")
+
+    def test_equality(self):
+        td1 = ToolDigest(tool_name="x", sha256="a" * 64)
+        td2 = ToolDigest(tool_name="x", sha256="a" * 64)
+        assert td1 == td2
+
+    def test_inequality_different_hash(self):
+        td1 = ToolDigest(tool_name="x", sha256="a" * 64)
+        td2 = ToolDigest(tool_name="x", sha256="b" * 64)
+        assert td1 != td2
+
+    def test_inequality_different_name(self):
+        td1 = ToolDigest(tool_name="x", sha256="a" * 64)
+        td2 = ToolDigest(tool_name="y", sha256="a" * 64)
+        assert td1 != td2
+
+    def test_hashable_for_frozenset(self):
+        td1 = ToolDigest(tool_name="x", sha256="a" * 64)
+        td2 = ToolDigest(tool_name="y", sha256="b" * 64)
+        fs = frozenset([td1, td2])
+        assert len(fs) == 2
+        assert td1 in fs
+
+    def test_accepts_all_hex_digits(self):
+        valid_hex = "0123456789abcdef" * 4
+        td = ToolDigest(tool_name="t", sha256=valid_hex)
+        assert td.sha256 == valid_hex
+
+
+class TestDigestEnforcement:
+    """DigestEnforcement enum values."""
+
+    def test_values(self):
+        assert DigestEnforcement.AUDIT == "audit"
+        assert DigestEnforcement.WARN == "warn"
+        assert DigestEnforcement.BLOCK == "block"
+
+    def test_from_string(self):
+        assert DigestEnforcement("audit") == DigestEnforcement.AUDIT
+        assert DigestEnforcement("block") == DigestEnforcement.BLOCK
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            DigestEnforcement("invalid")
+
+
+class TestDigestUnknownPolicy:
+    """DigestUnknownPolicy enum values."""
+
+    def test_values(self):
+        assert DigestUnknownPolicy.ALLOW_DEGRADED == "allow_degraded"
+        assert DigestUnknownPolicy.WARN == "warn"
+        assert DigestUnknownPolicy.BLOCK == "block"
+
+    def test_from_string(self):
+        assert DigestUnknownPolicy("allow_degraded") == DigestUnknownPolicy.ALLOW_DEGRADED
+
+
+class TestDigestPolicy:
+    """DigestPolicy value object behavior."""
+
+    @pytest.fixture
+    def sample_digest(self):
+        return ToolDigest(tool_name="read_file", sha256="a" * 64)
+
+    @pytest.fixture
+    def sample_policy(self, sample_digest):
+        return DigestPolicy(
+            enforcement=DigestEnforcement.BLOCK,
+            unknown=DigestUnknownPolicy.WARN,
+            allowlist=frozenset([sample_digest]),
+        )
+
+    def test_construction(self, sample_policy, sample_digest):
+        assert sample_policy.enforcement == DigestEnforcement.BLOCK
+        assert sample_policy.unknown == DigestUnknownPolicy.WARN
+        assert sample_digest in sample_policy.allowlist
+
+    def test_frozen_immutability(self, sample_policy):
+        with pytest.raises(AttributeError):
+            sample_policy.enforcement = DigestEnforcement.AUDIT  # type: ignore[misc]
+
+    def test_get_expected_digest_found(self, sample_policy, sample_digest):
+        result = sample_policy.get_expected_digest("read_file")
+        assert result == sample_digest
+
+    def test_get_expected_digest_not_found(self, sample_policy):
+        result = sample_policy.get_expected_digest("nonexistent_tool")
+        assert result is None
+
+    def test_empty_allowlist(self):
+        policy = DigestPolicy(
+            enforcement=DigestEnforcement.AUDIT,
+            unknown=DigestUnknownPolicy.ALLOW_DEGRADED,
+            allowlist=frozenset(),
+        )
+        assert policy.get_expected_digest("anything") is None
+
+    def test_multiple_tools_in_allowlist(self):
+        d1 = ToolDigest(tool_name="tool_a", sha256="a" * 64)
+        d2 = ToolDigest(tool_name="tool_b", sha256="b" * 64)
+        policy = DigestPolicy(
+            enforcement=DigestEnforcement.WARN,
+            unknown=DigestUnknownPolicy.BLOCK,
+            allowlist=frozenset([d1, d2]),
+        )
+        assert policy.get_expected_digest("tool_a") == d1
+        assert policy.get_expected_digest("tool_b") == d2
+        assert policy.get_expected_digest("tool_c") is None
+
+    def test_rejects_invalid_enforcement_type(self):
+        with pytest.raises(TypeError, match="enforcement must be"):
+            DigestPolicy(
+                enforcement="block",  # type: ignore[arg-type]
+                unknown=DigestUnknownPolicy.WARN,
+                allowlist=frozenset(),
+            )
+
+    def test_rejects_invalid_unknown_type(self):
+        with pytest.raises(TypeError, match="unknown must be"):
+            DigestPolicy(
+                enforcement=DigestEnforcement.BLOCK,
+                unknown="warn",  # type: ignore[arg-type]
+                allowlist=frozenset(),
+            )
+
+    def test_rejects_non_frozenset_allowlist(self):
+        with pytest.raises(TypeError, match="allowlist must be a frozenset"):
+            DigestPolicy(
+                enforcement=DigestEnforcement.BLOCK,
+                unknown=DigestUnknownPolicy.WARN,
+                allowlist=set(),  # type: ignore[arg-type]
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

ADR-004 (SEP-1766) mandates digest pinning for MCP tool supply chain integrity. The Python package scope requires local digest computation and standalone validation in non-cloud mode. None of the required domain types existed. Refs #118. Closes #119

## What

- `ToolDigest` frozen dataclass value object with SHA-256 hex validation (64 lowercase hex chars)
- `DigestEnforcement` StrEnum (`audit` / `warn` / `block`) per ADR design-choice table
- `DigestUnknownPolicy` StrEnum (`allow_degraded` / `warn` / `block`) for tools without known digest
- `DigestPolicy` frozen dataclass combining enforcement, unknown-tool handling, and `frozenset[ToolDigest]` allowlist
- `DigestMismatchEvent` domain event (follows existing `@dataclass` + `__post_init__` pattern from events.py)
- `compute_tool_digest()` helper: canonical JSON (`sort_keys=True`, `separators=(",",":")`) over `{name, description, inputSchema, outputSchema}` + SHA-256
- `DigestValidator` stateless domain service: validates tool schemas against policy allowlist, returns `DigestValidationResult` with optional `DigestMismatchEvent` (caller publishes)
- 60 unit tests (28 VO, 17 computation, 15 validator)
- CHANGELOG entry under `[Unreleased] > Added`

## How tested

- `uv run pytest tests/unit/domain/ -q` -- 274 passed (60 new, 0 regressions)
- `uv run ruff check` -- clean on all new/modified files
- `uv run ruff format --check` -- clean
- `uv run mypy` -- no new errors (3 pre-existing in enterprise/)
- Manual smoke tests for determinism, key-order independence, content sensitivity, validation edge cases

## Risk and rollback

Low risk. New domain types only -- no existing code references them yet. Revert single commit. No behavioral change to existing functionality.

## CHANGELOG note

- **core:** ADR-004 digest pinning domain types (`ToolDigest`, `DigestPolicy`, `DigestMismatchEvent`), canonical SHA-256 computation helper, and standalone `DigestValidator` service (#119)

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~350 production, ~524 tests
- [x] Files in scope match the issue brief