### PR TITLE
feat(core): add SEP-1763 interceptor discoverability and hook-based event model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Projects v2 board setup script and auto-add workflow
 - actionlint CI workflow to validate `.github/workflows/` YAML on PRs, push to main, and weekly schedule (#111)
 - **core:** ADR-004 digest pinning domain types (`ToolDigest`, `DigestPolicy`, `DigestMismatchEvent`), canonical SHA-256 computation helper, and standalone `DigestValidator` service (#119)
+- **core:** ADR-005 P1 interceptor framework: `Hook`/`HookPhase` value objects, `IHookSubscriber` contract, EventBus hook fan-out, and `GET /interceptors/list` endpoint for SEP-1763 discoverability (#120)
 
 ### Fixed
 

--- a/src/mcp_hangar/domain/contracts/hook_subscriber.py
+++ b/src/mcp_hangar/domain/contracts/hook_subscriber.py
@@ -1,0 +1,27 @@
+"""Hook subscriber contract for phase-aware event delivery.
+
+Defines IHookSubscriber so infrastructure can fan out Hook objects
+to subscribers without coupling to concrete implementations.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..value_objects.hook import Hook
+
+
+@runtime_checkable
+class IHookSubscriber(Protocol):
+    """Subscriber that receives phase-wrapped domain events."""
+
+    @abstractmethod
+    def on_hook(self, hook: Hook) -> None:
+        """Handle a hook delivery.
+
+        Args:
+            hook: Phase-wrapped domain event.
+        """
+        ...

--- a/src/mcp_hangar/domain/value_objects/hook.py
+++ b/src/mcp_hangar/domain/value_objects/hook.py
@@ -1,0 +1,55 @@
+"""Hook value objects for SEP-1763 interceptor framework compliance.
+
+Provides the hook abstraction that pairs a domain event with a phase marker,
+enabling phase-aware interception of the MCP event pipeline.
+
+- HookPhase: execution phase within the trust-boundary ordering
+- Hook: frozen wrapper pairing a DomainEvent with its phase and sequence
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ..events import DomainEvent
+
+
+class HookPhase(StrEnum):
+    """Execution phase within the SEP-1763 trust-boundary ordering.
+
+    Phases mirror the interceptor execution model:
+    Validate -> Mutate -> Send (outbound) / Validate -> Mutate -> Process (inbound).
+    """
+
+    PRE_VALIDATE = "pre_validate"
+    POST_VALIDATE = "post_validate"
+    PRE_MUTATE = "pre_mutate"
+    POST_MUTATE = "post_mutate"
+    OBSERVE = "observe"
+
+
+@dataclass(frozen=True)
+class Hook:
+    """Thin wrapper pairing a domain event with a phase marker.
+
+    Hooks provide phase-aware event delivery for interceptor subscribers
+    while keeping the existing flat-event path intact for backward compat.
+
+    Attributes:
+        event: The underlying domain event.
+        phase: Execution phase this hook was emitted at.
+        sequence_number: Monotonically increasing counter per correlation_id.
+    """
+
+    event: DomainEvent
+    phase: HookPhase
+    sequence_number: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event, DomainEvent):
+            raise TypeError("event must be a DomainEvent instance")
+        if not isinstance(self.phase, HookPhase):
+            raise TypeError("phase must be a HookPhase value")
+        if self.sequence_number < 0:
+            raise ValueError("sequence_number must be non-negative")

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -109,6 +109,7 @@ class MCPServerFactory:
 
         self._register_core_tools(mcp)
         self._register_discovery_tools(mcp)
+        self._register_interceptors_list(mcp)
 
         self._mcp = mcp
         logger.info(
@@ -321,6 +322,12 @@ class MCPServerFactory:
             if hgr.metrics is None:
                 return {"error": "Metrics not available"}
             return hgr.metrics(format=format)
+
+    @staticmethod
+    def _register_interceptors_list(mcp: FastMCP) -> None:
+        from .interceptors_list import interceptors_list_handler
+
+        mcp.custom_route("/interceptors/list", methods=["GET"], name="interceptors_list")(interceptors_list_handler)
 
     def _run_readiness_checks(self) -> dict[str, Any]:
         """Run readiness checks.

--- a/src/mcp_hangar/fastmcp_server/interceptors_list.py
+++ b/src/mcp_hangar/fastmcp_server/interceptors_list.py
@@ -1,0 +1,37 @@
+"""SEP-1763 ``interceptors/list`` HTTP endpoint.
+
+Exposes mcp-hangar as a discoverable interceptor per the SEP-1763
+specification (PR #2624). Registered as a custom HTTP route on the
+FastMCP server since the MCP SDK does not yet support custom JSON-RPC
+method registration for non-standard methods.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from mcp_hangar import __version__
+
+
+def interceptors_list_response() -> dict[str, Any]:
+    """Build the ``interceptors/list`` response payload."""
+    return {
+        "interceptors": [
+            {
+                "name": "mcp-hangar",
+                "version": __version__,
+                "type": "validator",
+                "supportedEvents": ["tools/call", "tools/list"],
+                "modes": ["audit", "enforce"],
+                "trustBoundary": "host",
+            },
+        ],
+    }
+
+
+async def interceptors_list_handler(request: Request) -> JSONResponse:
+    """Handle ``GET /interceptors/list``."""
+    return JSONResponse(interceptors_list_response())

--- a/src/mcp_hangar/infrastructure/event_bus.py
+++ b/src/mcp_hangar/infrastructure/event_bus.py
@@ -9,7 +9,9 @@ import threading
 
 from mcp_hangar.domain.contracts.event_bus import IEventBus
 from mcp_hangar.domain.contracts.event_store import IEventStore, NullEventStore
+from mcp_hangar.domain.contracts.hook_subscriber import IHookSubscriber
 from mcp_hangar.domain.events import DomainEvent
+from mcp_hangar.domain.value_objects.hook import Hook, HookPhase
 from mcp_hangar.infrastructure.lock_hierarchy import LockLevel, TrackedLock
 from mcp_hangar.logging_config import get_logger
 from mcp_hangar.observability.tracing import get_tracer
@@ -49,6 +51,8 @@ class EventBus(IEventBus):
         self._lock = TrackedLock(LockLevel.EVENT_BUS, "EventBus", reentrant=False)
         self._error_handlers: list[Callable[[Exception, DomainEvent], None]] = []
         self._event_store = event_store or NullEventStore()
+        self._hook_subscribers: list[IHookSubscriber] = []
+        self._hook_sequence: int = 0
 
     @property
     def event_store(self) -> IEventStore:
@@ -120,6 +124,32 @@ class EventBus(IEventBus):
             if event_type in self._handlers:
                 self._handlers[event_type].remove(handler)
 
+    def subscribe_hooks(self, subscriber: IHookSubscriber) -> None:
+        """Register a hook subscriber for phase-wrapped event delivery.
+
+        Hook subscribers receive Hook objects (event + phase) in parallel
+        with the existing flat-event path. This is the forward-looking API;
+        flat-event subscribers will be deprecated over time.
+
+        Args:
+            subscriber: Hook subscriber to register.
+        """
+        with self._lock:
+            self._hook_subscribers.append(subscriber)
+        logger.debug("hook_subscriber_registered", subscriber=type(subscriber).__name__)
+
+    def unsubscribe_hooks(self, subscriber: IHookSubscriber) -> None:
+        """Remove a hook subscriber. Silently ignores unregistered subscribers.
+
+        Args:
+            subscriber: Hook subscriber to remove.
+        """
+        with self._lock:
+            try:
+                self._hook_subscribers.remove(subscriber)
+            except ValueError:
+                pass
+
     def publish(self, event: DomainEvent) -> None:
         """
         Publish an event to all subscribed handlers.
@@ -174,6 +204,12 @@ class EventBus(IEventBus):
                                 event_type=event_type_name,
                                 error=str(eh),
                             )
+
+            # Hook fan-out: deliver phase-wrapped event to hook subscribers.
+            # Default phase is OBSERVE for events published via the flat API;
+            # phase-specific emission will be added when interceptor pipeline
+            # code lands (issue #121).
+            self._publish_hook(event, HookPhase.OBSERVE, evt_span)
 
     def publish_to_stream(
         self,
@@ -250,6 +286,30 @@ class EventBus(IEventBus):
         stream_id = f"{aggregate_type}:{aggregate_id}"
         return self.publish_to_stream(stream_id, events, expected_version)
 
+    def _publish_hook(self, event: DomainEvent, phase: HookPhase, span: object) -> None:
+        with self._lock:
+            subscribers = list(self._hook_subscribers)
+            seq = self._hook_sequence
+            self._hook_sequence += 1
+
+        if not subscribers:
+            return
+
+        hook = Hook(event=event, phase=phase, sequence_number=seq)
+        for subscriber in subscribers:
+            try:
+                subscriber.on_hook(hook)
+            except Exception as e:  # noqa: BLE001 -- fault-barrier: hook subscriber errors must not break event publishing
+                logger.exception(
+                    "hook_subscriber_error",
+                    event_type=event.__class__.__name__,
+                    phase=phase.value,
+                    subscriber=type(subscriber).__name__,
+                    error=str(e),
+                )
+                if hasattr(span, "record_exception"):
+                    span.record_exception(e)
+
     def on_error(self, handler: Callable[[Exception, DomainEvent], None]) -> None:
         """
         Register a handler for errors that occur during event handling.
@@ -264,6 +324,8 @@ class EventBus(IEventBus):
         with self._lock:
             self._handlers.clear()
             self._error_handlers.clear()
+            self._hook_subscribers.clear()
+            self._hook_sequence = 0
 
 
 # Global event bus instance

--- a/tests/unit/domain/value_objects/test_hook.py
+++ b/tests/unit/domain/value_objects/test_hook.py
@@ -1,0 +1,97 @@
+"""Unit tests for Hook and HookPhase value objects."""
+
+import pytest
+
+from mcp_hangar.domain.events import DomainEvent
+from mcp_hangar.domain.value_objects.hook import Hook, HookPhase
+
+
+class _StubEvent(DomainEvent):
+    """Minimal concrete event for testing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class TestHookPhase:
+
+    def test_all_phases_are_strings(self):
+        assert HookPhase.PRE_VALIDATE == "pre_validate"
+        assert HookPhase.POST_VALIDATE == "post_validate"
+        assert HookPhase.PRE_MUTATE == "pre_mutate"
+        assert HookPhase.POST_MUTATE == "post_mutate"
+        assert HookPhase.OBSERVE == "observe"
+
+    def test_phase_count(self):
+        assert len(HookPhase) == 5
+
+    def test_phase_from_string(self):
+        assert HookPhase("pre_validate") is HookPhase.PRE_VALIDATE
+
+    def test_invalid_phase_raises(self):
+        with pytest.raises(ValueError):
+            HookPhase("nonexistent")
+
+
+class TestHook:
+
+    def test_valid_hook(self):
+        evt = _StubEvent()
+        hook = Hook(event=evt, phase=HookPhase.OBSERVE, sequence_number=0)
+        assert hook.event is evt
+        assert hook.phase is HookPhase.OBSERVE
+        assert hook.sequence_number == 0
+
+    def test_frozen_immutability(self):
+        hook = Hook(event=_StubEvent(), phase=HookPhase.OBSERVE, sequence_number=0)
+        with pytest.raises(AttributeError):
+            hook.sequence_number = 5  # type: ignore[misc]
+
+    def test_rejects_non_domain_event(self):
+        with pytest.raises(TypeError, match="event must be a DomainEvent"):
+            Hook(event="not_an_event", phase=HookPhase.OBSERVE, sequence_number=0)  # type: ignore[arg-type]
+
+    def test_rejects_non_hook_phase(self):
+        with pytest.raises(TypeError, match="phase must be a HookPhase"):
+            Hook(event=_StubEvent(), phase="observe", sequence_number=0)  # type: ignore[arg-type]
+
+    def test_rejects_negative_sequence(self):
+        with pytest.raises(ValueError, match="sequence_number must be non-negative"):
+            Hook(event=_StubEvent(), phase=HookPhase.OBSERVE, sequence_number=-1)
+
+    def test_zero_sequence_is_valid(self):
+        hook = Hook(event=_StubEvent(), phase=HookPhase.OBSERVE, sequence_number=0)
+        assert hook.sequence_number == 0
+
+    def test_large_sequence_number(self):
+        hook = Hook(event=_StubEvent(), phase=HookPhase.PRE_VALIDATE, sequence_number=999_999)
+        assert hook.sequence_number == 999_999
+
+    def test_all_phases_accepted(self):
+        for phase in HookPhase:
+            hook = Hook(event=_StubEvent(), phase=phase, sequence_number=0)
+            assert hook.phase is phase
+
+    def test_equality(self):
+        evt = _StubEvent()
+        h1 = Hook(event=evt, phase=HookPhase.OBSERVE, sequence_number=1)
+        h2 = Hook(event=evt, phase=HookPhase.OBSERVE, sequence_number=1)
+        assert h1 == h2
+
+    def test_different_phase_not_equal(self):
+        evt = _StubEvent()
+        h1 = Hook(event=evt, phase=HookPhase.OBSERVE, sequence_number=1)
+        h2 = Hook(event=evt, phase=HookPhase.PRE_VALIDATE, sequence_number=1)
+        assert h1 != h2
+
+    def test_different_sequence_not_equal(self):
+        evt = _StubEvent()
+        h1 = Hook(event=evt, phase=HookPhase.OBSERVE, sequence_number=1)
+        h2 = Hook(event=evt, phase=HookPhase.OBSERVE, sequence_number=2)
+        assert h1 != h2
+
+    def test_hook_preserves_event_attributes(self):
+        evt = _StubEvent()
+        hook = Hook(event=evt, phase=HookPhase.OBSERVE, sequence_number=0)
+        assert hasattr(hook.event, "event_id")
+        assert hasattr(hook.event, "occurred_at")

--- a/tests/unit/test_hook_fanout.py
+++ b/tests/unit/test_hook_fanout.py
@@ -1,0 +1,116 @@
+"""Unit tests for EventBus hook fan-out."""
+
+from mcp_hangar.domain.events import DomainEvent
+from mcp_hangar.domain.value_objects.hook import Hook, HookPhase
+from mcp_hangar.infrastructure.event_bus import EventBus
+
+
+class _StubEvent(DomainEvent):
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class _RecordingSubscriber:
+    """Captures hooks for assertion."""
+
+    def __init__(self) -> None:
+        self.hooks: list[Hook] = []
+
+    def on_hook(self, hook: Hook) -> None:
+        self.hooks.append(hook)
+
+
+class _FailingSubscriber:
+    def on_hook(self, hook: Hook) -> None:
+        raise RuntimeError("boom")
+
+
+class TestEventBusHookFanOut:
+
+    def setup_method(self) -> None:
+        self.bus = EventBus()
+
+    def test_hook_delivered_on_publish(self):
+        sub = _RecordingSubscriber()
+        self.bus.subscribe_hooks(sub)
+        evt = _StubEvent()
+        self.bus.publish(evt)
+
+        assert len(sub.hooks) == 1
+        assert sub.hooks[0].event is evt
+        assert sub.hooks[0].phase is HookPhase.OBSERVE
+        assert sub.hooks[0].sequence_number == 0
+
+    def test_sequence_increments(self):
+        sub = _RecordingSubscriber()
+        self.bus.subscribe_hooks(sub)
+        self.bus.publish(_StubEvent())
+        self.bus.publish(_StubEvent())
+        self.bus.publish(_StubEvent())
+
+        assert [h.sequence_number for h in sub.hooks] == [0, 1, 2]
+
+    def test_multiple_subscribers_all_receive(self):
+        s1 = _RecordingSubscriber()
+        s2 = _RecordingSubscriber()
+        self.bus.subscribe_hooks(s1)
+        self.bus.subscribe_hooks(s2)
+        self.bus.publish(_StubEvent())
+
+        assert len(s1.hooks) == 1
+        assert len(s2.hooks) == 1
+
+    def test_unsubscribe_stops_delivery(self):
+        sub = _RecordingSubscriber()
+        self.bus.subscribe_hooks(sub)
+        self.bus.publish(_StubEvent())
+        assert len(sub.hooks) == 1
+
+        self.bus.unsubscribe_hooks(sub)
+        self.bus.publish(_StubEvent())
+        assert len(sub.hooks) == 1
+
+    def test_unsubscribe_unknown_is_silent(self):
+        sub = _RecordingSubscriber()
+        self.bus.unsubscribe_hooks(sub)
+
+    def test_failing_subscriber_does_not_break_others(self):
+        s1 = _RecordingSubscriber()
+        fail = _FailingSubscriber()
+        s2 = _RecordingSubscriber()
+        self.bus.subscribe_hooks(s1)
+        self.bus.subscribe_hooks(fail)
+        self.bus.subscribe_hooks(s2)
+        self.bus.publish(_StubEvent())
+
+        assert len(s1.hooks) == 1
+        assert len(s2.hooks) == 1
+
+    def test_flat_handlers_still_work_alongside_hooks(self):
+        flat_events: list[DomainEvent] = []
+        self.bus.subscribe(_StubEvent, lambda e: flat_events.append(e))
+        sub = _RecordingSubscriber()
+        self.bus.subscribe_hooks(sub)
+
+        evt = _StubEvent()
+        self.bus.publish(evt)
+
+        assert len(flat_events) == 1
+        assert flat_events[0] is evt
+        assert len(sub.hooks) == 1
+        assert sub.hooks[0].event is evt
+
+    def test_no_hook_subscribers_no_error(self):
+        self.bus.publish(_StubEvent())
+
+    def test_clear_resets_hook_subscribers_and_sequence(self):
+        sub = _RecordingSubscriber()
+        self.bus.subscribe_hooks(sub)
+        self.bus.publish(_StubEvent())
+        assert sub.hooks[0].sequence_number == 0
+
+        self.bus.clear()
+        sub2 = _RecordingSubscriber()
+        self.bus.subscribe_hooks(sub2)
+        self.bus.publish(_StubEvent())
+        assert sub2.hooks[0].sequence_number == 0

--- a/tests/unit/test_interceptors_list.py
+++ b/tests/unit/test_interceptors_list.py
@@ -1,0 +1,56 @@
+"""Unit tests for interceptors/list endpoint."""
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from mcp_hangar.fastmcp_server.interceptors_list import (
+    interceptors_list_handler,
+    interceptors_list_response,
+)
+
+
+class TestInterceptorsListResponse:
+
+    def test_response_shape(self):
+        data = interceptors_list_response()
+        assert "interceptors" in data
+        assert len(data["interceptors"]) == 1
+
+    def test_interceptor_fields(self):
+        interceptor = interceptors_list_response()["interceptors"][0]
+        assert interceptor["name"] == "mcp-hangar"
+        assert isinstance(interceptor["version"], str)
+        assert interceptor["type"] == "validator"
+        assert interceptor["supportedEvents"] == ["tools/call", "tools/list"]
+        assert interceptor["modes"] == ["audit", "enforce"]
+        assert interceptor["trustBoundary"] == "host"
+
+    def test_version_is_nonempty(self):
+        interceptor = interceptors_list_response()["interceptors"][0]
+        assert len(interceptor["version"]) > 0
+
+
+class TestInterceptorsListEndpoint:
+
+    @pytest.fixture()
+    def client(self) -> TestClient:
+        app = Starlette(routes=[
+            Route("/interceptors/list", interceptors_list_handler, methods=["GET"]),
+        ])
+        return TestClient(app)
+
+    def test_get_returns_200(self, client: TestClient):
+        resp = client.get("/interceptors/list")
+        assert resp.status_code == 200
+
+    def test_get_returns_json(self, client: TestClient):
+        resp = client.get("/interceptors/list")
+        assert resp.headers["content-type"] == "application/json"
+        data = resp.json()
+        assert "interceptors" in data
+
+    def test_post_not_allowed(self, client: TestClient):
+        resp = client.post("/interceptors/list")
+        assert resp.status_code == 405


### PR DESCRIPTION
## Why

ADR-005 P1 mandates interceptor discoverability (`interceptors/list`) and migration from flat events to hook-based event model. This is the foundation for IMutator (issue #121) and wildcard subscriptions (issue #122). Closes #120

## What

- Add `Hook` (frozen dataclass) and `HookPhase` (StrEnum with 5 phases) value objects for SEP-1763 interceptor framework compliance
- Add `IHookSubscriber` protocol contract for phase-aware event delivery
- Extend `EventBus.publish()` with parallel hook fan-out (backward-compatible; existing flat-event subscribers unaffected)
- Add `GET /interceptors/list` HTTP endpoint exposing mcp-hangar as a discoverable SEP-1763 interceptor
- 31 new unit tests covering VOs, fan-out, and endpoint

### New files
- `src/mcp_hangar/domain/value_objects/hook.py` -- Hook + HookPhase
- `src/mcp_hangar/domain/contracts/hook_subscriber.py` -- IHookSubscriber Protocol
- `src/mcp_hangar/fastmcp_server/interceptors_list.py` -- endpoint handler
- `tests/unit/domain/value_objects/test_hook.py` -- 16 tests
- `tests/unit/test_hook_fanout.py` -- 9 tests
- `tests/unit/test_interceptors_list.py` -- 6 tests

### Modified files
- `src/mcp_hangar/infrastructure/event_bus.py` -- subscribe_hooks/unsubscribe_hooks/_publish_hook + fan-out in publish()
- `src/mcp_hangar/fastmcp_server/factory.py` -- register interceptors/list route
- `CHANGELOG.md` -- entry under [Unreleased] / Added

### Design decisions
1. **HTTP endpoint, not JSON-RPC method**: MCP SDK dispatches JSON-RPC by Pydantic type with no extension point for custom methods. `custom_route` is the supported API. Trivial to migrate when SDK adds support.
2. **No re-export from `value_objects/__init__`**: Avoids circular import chain (`events.py` -> `__init__` -> `hook.py` -> `events.py`).
3. **Default phase OBSERVE**: Events via flat API get OBSERVE. Phase-specific emission comes with #121 (IMutator pipeline).

## How tested

- 31 new unit tests (Hook validation, HookPhase enum, EventBus fan-out including fault isolation, interceptors/list response shape and HTTP behavior)
- Full unit suite: 3866 passed, 1 pre-existing skip
- ruff check + format: clean
- mypy: clean (3 pre-existing enterprise errors unrelated to this PR)

## Risk and rollback

Low. Hook fan-out is additive (no hook subscribers registered by default = no-op path). Existing event bus behavior unchanged. Revert single commit.

## CHANGELOG note

- **core:** ADR-005 hook-based event model (`Hook`, `HookPhase`, `IHookSubscriber`), EventBus hook fan-out, and `GET /interceptors/list` endpoint (#120)

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~350
- [x] Files in scope match the issue brief