### PR TITLE
chore(core): close epic #118 with e2e test, ADR status, and arch doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** ADR-005 P1 interceptor framework: `Hook`/`HookPhase` value objects, `IHookSubscriber` contract, EventBus hook fan-out, and `GET /interceptors/list` endpoint for SEP-1763 discoverability (#120)
 - **core:** ADR-005 P1 mutator framework: `IMutator` contract, `MutationContext`/`MutationResult` VOs, priority-based `MutatorPipeline`, `ResponseTruncator` mutator with `ResponseTruncated` event (#121)
 - **core:** ADR-005 wildcard event subscription patterns via `EventPattern` value object and `compile_event_patterns()` helper (#122)
+- **core:** Epic #118 closure: end-to-end integration test for ADR-004/ADR-005 pipeline, ADR implementation status annotations, and interceptor framework architecture doc
 
 ### Fixed
 

--- a/docs/adr/ADR-004-sep-1766-digest-pinning.md
+++ b/docs/adr/ADR-004-sep-1766-digest-pinning.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-05-01
 **Authors:** MCP Hangar Team
+**Implementation:** P1 complete in v1.2.0 (epic #118). Domain types, digest computation, and standalone validator landed in PRs #123, #136, #137, #138.
 
 ## Context
 

--- a/docs/adr/ADR-005-sep-1763-interceptor-compliance.md
+++ b/docs/adr/ADR-005-sep-1763-interceptor-compliance.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-05-01
 **Authors:** MCP Hangar Team
+**Implementation:** P1 complete in v1.2.0 (epic #118). Hook model, IMutator contract, MutatorPipeline, ResponseTruncator, wildcard subscriptions, and interceptors/list landed in PRs #136, #137, #138.
 
 ## Context
 

--- a/docs/architecture/INTERCEPTOR_FRAMEWORK.md
+++ b/docs/architecture/INTERCEPTOR_FRAMEWORK.md
@@ -1,0 +1,108 @@
+# Interceptor Framework
+
+MCP Hangar implements the SEP-1763 interceptor framework with hook-based event delivery and priority-ordered mutator pipelines. See [ADR-005](../adr/ADR-005-sep-1763-interceptor-compliance.md) for design rationale.
+
+## Architecture
+
+```
+Tool invocation
+    |
+    v
+DigestValidator            (ADR-004: schema integrity check)
+    |  emits DigestMismatchEvent on mismatch
+    v
+MutatorPipeline            (ADR-005: sequential transformation)
+    |  ResponseTruncator, future: PII redaction, schema enforcement
+    v
+EventBus.publish()
+    |
+    +---> flat subscribers     (backward-compatible)
+    +---> hook subscribers     (phase-wrapped Hook objects)
+    +---> wildcard filters     (EventPattern matching)
+```
+
+## Components
+
+### Digest Pinning (ADR-004)
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `ToolDigest` | `domain/value_objects/tool_digest.py` | SHA-256 fingerprint of a tool's canonical schema |
+| `DigestPolicy` | `domain/value_objects/tool_digest.py` | Enforcement level + unknown-tool handling + allowlist |
+| `DigestEnforcement` | `domain/value_objects/tool_digest.py` | Enum: `audit`, `warn`, `block` |
+| `compute_tool_digest()` | `domain/services/digest_computation.py` | Deterministic SHA-256 over canonical JSON |
+| `DigestValidator` | `domain/services/digest_validator.py` | Validates tools against policy, emits `DigestMismatchEvent` |
+
+### Hook-Based Event Model (ADR-005)
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `HookPhase` | `domain/value_objects/hook.py` | Enum: `BEFORE`, `AROUND`, `AFTER`, `ON_ERROR`, `OBSERVE` |
+| `Hook` | `domain/value_objects/hook.py` | Wraps `(event, phase, sequence_number)` |
+| `IHookSubscriber` | `domain/contracts/hook_subscriber.py` | Protocol for phase-aware event delivery |
+| `EventBus` | `infrastructure/event_bus.py` | Fan-out to both flat subscribers and hook subscribers |
+
+### Mutator Pipeline (ADR-005)
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `IMutator` | `domain/contracts/mutator.py` | Protocol: `priority_hint`, `applies_to`, `mutate()` |
+| `MutationContext` | `domain/contracts/mutator.py` | Input: method, direction, payload, correlation_id |
+| `MutationResult` | `domain/contracts/mutator.py` | Output: payload, changed flag, audit_only flag |
+| `MutatorPipeline` | `application/services/mutator_pipeline.py` | Sorts by `(priority_hint, registration_index)`, executes sequentially |
+| `ResponseTruncator` | `application/mutators/response_truncator.py` | Truncates oversized `tools/call` responses, emits `ResponseTruncated` |
+
+### Wildcard Subscriptions (ADR-005)
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `EventPattern` | `domain/value_objects/event_pattern.py` | Segment-wise wildcard matching (`*`, `tools/*`, `*/response`) |
+| `compile_event_patterns()` | `server/api/ws/filters.py` | Compiles raw strings into `EventPattern` objects |
+| `matches_filters()` | `server/api/ws/filters.py` | Tests events against wildcard-aware subscription filters |
+
+### Interceptor Discoverability
+
+`GET /interceptors/list` returns mcp-hangar's capabilities as a SEP-1763 interceptor:
+
+```json
+{
+  "interceptors": [
+    {
+      "name": "mcp-hangar",
+      "version": "<package version>",
+      "types": ["validator", "mutator", "observer"],
+      "capabilities": {
+        "failOpen": true,
+        "auditMode": true,
+        "trustBoundaryAware": true
+      }
+    }
+  ]
+}
+```
+
+## Mutator Ordering
+
+Mutators execute in ascending `priority_hint` order. Ties are broken by registration order (stable sort).
+
+| Mutator | priority_hint | Rationale |
+|---------|--------------|-----------|
+| (future: PII redactor) | 100 | Runs early to redact before other transforms |
+| (future: schema enforcer) | 500 | Validates structure after redaction |
+| ResponseTruncator | 1000 | Runs last to truncate after all other transforms |
+
+## Event Flow
+
+1. `DigestValidator.validate_tool()` produces `DigestValidationResult` with optional `DigestMismatchEvent`.
+2. Caller publishes events via `EventBus.publish()`.
+3. EventBus delivers to flat subscribers (type-matched), hook subscribers (phase-wrapped), and wildcard-filtered WebSocket streams.
+4. `MutatorPipeline.execute()` runs registered mutators sequentially.
+5. Mutators collect domain events (e.g., `ResponseTruncated`) via `event_collector` list pattern.
+6. Caller publishes mutator events to EventBus for audit trail.
+
+## P2 Items (Not Yet Implemented)
+
+- `interceptor/invoke` JSON-RPC method (explicit invocation mode)
+- Shadow mutations (audit mode on mutators)
+- Per-interceptor `failOpen` granularity
+- Extended lifecycle events (`resources/*`, `prompts/*`, `sampling/*`, `elicitation/*`, `roots/*`)

--- a/tests/integration/test_adr_e2e_flow.py
+++ b/tests/integration/test_adr_e2e_flow.py
@@ -1,0 +1,251 @@
+"""End-to-end integration tests for ADR-004 + ADR-005 domain wiring.
+
+Verifies that tool invocations pass through validators -> mutators -> audit,
+and that a digest mismatch produces a DigestMismatchEvent consumed by a handler.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_hangar.application.mutators.response_truncator import ResponseTruncator
+from mcp_hangar.application.services.mutator_pipeline import MutatorPipeline
+from mcp_hangar.domain.contracts.hook_subscriber import IHookSubscriber
+from mcp_hangar.domain.contracts.mutator import MutationContext
+from mcp_hangar.domain.events import DigestMismatchEvent, DomainEvent, ResponseTruncated
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.domain.services.digest_validator import DigestValidator
+from mcp_hangar.domain.value_objects.event_pattern import EventPattern
+from mcp_hangar.domain.value_objects.hook import Hook, HookPhase
+from mcp_hangar.domain.value_objects.tool_digest import (
+    DigestEnforcement,
+    DigestPolicy,
+    DigestUnknownPolicy,
+    ToolDigest,
+)
+from mcp_hangar.infrastructure.event_bus import EventBus
+from mcp_hangar.server.api.ws.filters import matches_filters
+
+
+SAMPLE_TOOL: dict[str, Any] = {
+    "name": "get_weather",
+    "description": "Returns current weather for a city.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}
+
+
+def _make_policy_with_correct_digest() -> DigestPolicy:
+    digest = compute_tool_digest(SAMPLE_TOOL)
+    return DigestPolicy(
+        enforcement=DigestEnforcement.BLOCK,
+        unknown=DigestUnknownPolicy.WARN,
+        allowlist=frozenset({digest}),
+    )
+
+
+def _make_policy_with_wrong_digest() -> DigestPolicy:
+    wrong = ToolDigest(tool_name="get_weather", sha256="a" * 64)
+    return DigestPolicy(
+        enforcement=DigestEnforcement.BLOCK,
+        unknown=DigestUnknownPolicy.WARN,
+        allowlist=frozenset({wrong}),
+    )
+
+
+class TestDigestValidationToEventBus:
+    """DigestValidator -> DigestMismatchEvent -> EventBus -> subscriber."""
+
+    def test_digest_match_produces_no_event(self):
+        validator = DigestValidator(_make_policy_with_correct_digest())
+        result = validator.validate_tool(SAMPLE_TOOL, "srv-1", "corr-1")
+
+        assert result.valid is True
+        assert result.blocked is False
+        assert result.event is None
+
+    def test_digest_mismatch_produces_event_consumed_by_handler(self):
+        validator = DigestValidator(_make_policy_with_wrong_digest())
+        result = validator.validate_tool(SAMPLE_TOOL, "srv-1", "corr-1")
+
+        assert result.valid is False
+        assert result.blocked is True
+        assert result.event is not None
+
+        captured: list[DomainEvent] = []
+        bus = EventBus()
+        bus.subscribe(DigestMismatchEvent, captured.append)
+        bus.publish(result.event)
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert isinstance(event, DigestMismatchEvent)
+        assert event.tool_name == "get_weather"
+        assert event.expected_digest == "a" * 64
+        assert event.enforcement == "block"
+
+    def test_digest_mismatch_reaches_hook_subscriber(self):
+        validator = DigestValidator(_make_policy_with_wrong_digest())
+        result = validator.validate_tool(SAMPLE_TOOL, "srv-1", "corr-1")
+
+        hook_log: list[Hook] = []
+
+        class _Recorder(IHookSubscriber):
+            def on_hook(self, hook: Hook) -> None:
+                hook_log.append(hook)
+
+        bus = EventBus()
+        bus.subscribe_hooks(_Recorder())
+        assert result.event is not None
+        bus.publish(result.event)
+
+        assert len(hook_log) == 1
+        assert hook_log[0].phase == HookPhase.OBSERVE
+        assert isinstance(hook_log[0].event, DigestMismatchEvent)
+
+
+class TestMutatorPipelineEndToEnd:
+    """MutatorPipeline + ResponseTruncator -> ResponseTruncated event."""
+
+    def test_truncator_truncates_and_emits_event(self):
+        events: list[Any] = []
+        truncator = ResponseTruncator(max_bytes=50, event_collector=events)
+
+        pipeline = MutatorPipeline()
+        pipeline.register(truncator)
+
+        big_result = "x" * 200
+        ctx = MutationContext(
+            method="tools/call",
+            direction="response",
+            payload={"result": big_result},
+            correlation_id="corr-2",
+        )
+        out = pipeline.execute(ctx)
+
+        assert out.changed is True
+        assert len(out.payload["result"]) < len(big_result)
+
+        assert len(events) == 1
+        assert isinstance(events[0], ResponseTruncated)
+        assert events[0].method == "tools/call"
+        assert events[0].original_size > 50
+
+    def test_truncator_skips_small_response(self):
+        events: list[Any] = []
+        truncator = ResponseTruncator(max_bytes=50000, event_collector=events)
+
+        pipeline = MutatorPipeline()
+        pipeline.register(truncator)
+
+        ctx = MutationContext(
+            method="tools/call",
+            direction="response",
+            payload={"result": "small"},
+            correlation_id="corr-3",
+        )
+        out = pipeline.execute(ctx)
+
+        assert out.changed is False
+        assert len(events) == 0
+
+    def test_truncator_event_reaches_event_bus(self):
+        events: list[Any] = []
+        truncator = ResponseTruncator(max_bytes=50, event_collector=events)
+
+        pipeline = MutatorPipeline()
+        pipeline.register(truncator)
+
+        ctx = MutationContext(
+            method="tools/call",
+            direction="response",
+            payload={"result": "y" * 200},
+            correlation_id="corr-4",
+        )
+        pipeline.execute(ctx)
+
+        bus_log: list[DomainEvent] = []
+        bus = EventBus()
+        bus.subscribe(ResponseTruncated, bus_log.append)
+
+        for ev in events:
+            bus.publish(ev)
+
+        assert len(bus_log) == 1
+        assert isinstance(bus_log[0], ResponseTruncated)
+
+
+class TestFullPipelineFlow:
+    """Digest validation -> mutator pipeline -> event bus audit trail."""
+
+    def test_mismatch_then_truncation_events_all_reach_audit(self):
+        audit_log: list[DomainEvent] = []
+        bus = EventBus()
+        bus.subscribe_to_all(audit_log.append)
+
+        # Step 1: digest validation produces mismatch event
+        validator = DigestValidator(_make_policy_with_wrong_digest())
+        result = validator.validate_tool(SAMPLE_TOOL, "srv-1", "corr-full")
+
+        assert result.event is not None
+        bus.publish(result.event)
+
+        # Step 2: mutator pipeline truncates oversized response
+        mutator_events: list[Any] = []
+        truncator = ResponseTruncator(max_bytes=30, event_collector=mutator_events)
+        pipeline = MutatorPipeline()
+        pipeline.register(truncator)
+
+        ctx = MutationContext(
+            method="tools/call",
+            direction="response",
+            payload={"result": "z" * 300},
+            correlation_id="corr-full",
+        )
+        pipeline.execute(ctx)
+
+        for ev in mutator_events:
+            bus.publish(ev)
+
+        # Both events reached the audit subscriber
+        assert len(audit_log) == 2
+        types = {type(e) for e in audit_log}
+        assert DigestMismatchEvent in types
+        assert ResponseTruncated in types
+
+        # Same correlation_id across the pipeline
+        assert all(getattr(e, "correlation_id", None) == "corr-full" for e in audit_log)
+
+
+class TestWildcardSubscriptionFiltering:
+    """EventPattern + matches_filters integration with real events."""
+
+    def test_wildcard_pattern_filters_events(self):
+        pattern = EventPattern("tools/*")
+        assert pattern.matches("tools/call") is True
+        assert pattern.matches("tools/list") is True
+        assert pattern.matches("resources/read") is False
+
+    def test_matches_filters_with_wildcard_and_real_event(self):
+        mismatch = DigestMismatchEvent(
+            mcp_server_id="srv-1",
+            tool_name="get_weather",
+            expected_digest="a" * 64,
+            observed_digest="b" * 64,
+            enforcement="block",
+            correlation_id="corr-w",
+        )
+        # DigestMismatchEvent event_type has no "/" -> won't match tools/*
+        filters_tools = {"event_types": ["tools/*"]}
+        assert matches_filters(mismatch, filters_tools) is False
+
+        # Exact match by class name works
+        filters_exact = {"event_types": ["DigestMismatchEvent"]}
+        assert matches_filters(mismatch, filters_exact) is True
+
+        # Star matches everything
+        filters_star = {"event_types": ["*"]}
+        assert matches_filters(mismatch, filters_star) is True


### PR DESCRIPTION
## Why

Epic #118 acceptance criteria require an end-to-end integration test, ADR implementation status annotations, and an architecture doc for the interceptor framework. All four child PRs (#123, #136, #137, #138) are merged; this PR satisfies the remaining epic-level AC items. Closes #118

## What

- Add `tests/integration/test_adr_e2e_flow.py` (9 tests): DigestValidator -> EventBus subscriber, DigestMismatchEvent -> hook subscriber, MutatorPipeline + ResponseTruncator -> ResponseTruncated event, full pipeline flow with correlated audit trail, wildcard subscription filtering with real events
- Add `Implementation` status line to ADR-004 and ADR-005 headers pointing at epic #118 and v1.2.0
- Add `docs/architecture/INTERCEPTOR_FRAMEWORK.md` describing the hook/mutator model, component inventory, mutator ordering, and P2 items

## How tested

- `uv run pytest tests/integration/test_adr_e2e_flow.py -v` -- 9 passed
- Full suite: 4236 passed, 0 failures
- ruff check + format: clean
- mypy: clean (3 pre-existing langfuse errors only)

## Risk and rollback

No risk. All new files (test + doc) and one-line ADR header additions. Revert single commit.

## CHANGELOG note

- **core:** Epic #118 closure: end-to-end integration test for ADR-004/ADR-005 pipeline, ADR implementation status annotations, and interceptor framework architecture doc

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~360
- [x] Files in scope match the issue brief