### PR TITLE
fix(docs): correct stale metrics section in OBSERVABILITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **docs:** remove stale "Metrics Not Yet Implemented" section from OBSERVABILITY.md; all listed metrics are live in `metrics.py` since v1.1.0 (#135)
 - **ci:** release notes no longer contain literal `%0A` newlines (removed legacy set-output encoding)
 - **ci:** release body no longer has a duplicated `## What's Changed` section (removed `generate_release_notes: true`); a manual Full Changelog compare link is added instead
 - **ci:** HTML entities (`&gt;`, `&lt;`, `&amp;`) in CHANGELOG entries are decoded before writing to the release body

--- a/docs/guides/OBSERVABILITY.md
+++ b/docs/guides/OBSERVABILITY.md
@@ -204,8 +204,35 @@ sum(rate(mcp_hangar_health_checks_total{result="healthy"}[5m])) by (mcp_server)
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `mcp_hangar_mcp_server_starts_total` | Counter | MCP server | MCP Server start attempts |
-| `mcp_hangar_mcp_server_initialized` | Gauge | MCP server | 1 if MCP server has been initialized |
+| `mcp_hangar_mcp_server_state` | Gauge | mcp_server | Current state (0=cold, 1=initializing, 2=ready, 3=degraded, 4=dead) |
+| `mcp_hangar_mcp_server_up` | Gauge | mcp_server | 1 if MCP server is reachable |
+| `mcp_hangar_mcp_server_starts_total` | Counter | mcp_server | MCP server start attempts |
+| `mcp_hangar_mcp_server_initialized` | Gauge | mcp_server | 1 if MCP server has been initialized |
+| `mcp_hangar_mcp_server_cold_start_seconds` | Histogram | mcp_server | Cold start latency |
+| `mcp_hangar_mcp_server_cold_start_in_progress` | Gauge | mcp_server | 1 if cold start is in progress |
+
+#### Discovery
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mcp_hangar_discovery_mcp_servers` | Gauge | source | Discovered MCP servers per source |
+| `mcp_hangar_discovery_registrations_total` | Counter | source | New registrations |
+| `mcp_hangar_discovery_errors_total` | Counter | source | Errors by source |
+| `mcp_hangar_discovery_cycle_duration_seconds` | Histogram | source | Discovery cycle duration |
+
+#### HTTP Transport
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mcp_hangar_http_requests_total` | Counter | method, status | HTTP requests to remote MCP servers |
+| `mcp_hangar_http_request_duration_seconds` | Histogram | method | HTTP request latency |
+| `mcp_hangar_http_connections` | Gauge | mcp_server | Active HTTP connections |
+
+#### Rate Limiting
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mcp_hangar_rate_limit_hits_total` | Counter | principal | Rate limit rejections |
 
 #### GC (Garbage Collection)
 
@@ -213,18 +240,6 @@ sum(rate(mcp_hangar_health_checks_total{result="healthy"}[5m])) by (mcp_server)
 |--------|------|--------|-------------|
 | `mcp_hangar_gc_cycles_total` | Counter | - | GC cycle executions |
 | `mcp_hangar_gc_cycle_duration_seconds` | Histogram | - | GC cycle duration |
-
-### Metrics Not Yet Implemented
-
-The following metrics are defined in code but not currently populated. They are planned for future releases:
-
-- `mcp_hangar_mcp_server_state` - MCP server state gauge (cold/ready/degraded/dead)
-- `mcp_hangar_mcp_server_up` - MCP Server availability
-- `mcp_hangar_mcp_server_cold_start_seconds` - Cold start latency histogram
-- `mcp_hangar_discovery_*` - Auto-discovery metrics
-- `mcp_hangar_http_*` - HTTP transport metrics (for remote MCP servers)
-- `mcp_hangar_rate_limit_hits_total` - Rate limiting metrics
-- `mcp_hangar_connections_*` - Connection tracking
 
 ## Grafana Dashboards
 


### PR DESCRIPTION
## Why

The OBSERVABILITY.md guide had a "Metrics Not Yet Implemented" section hedging
that metrics were planned -- but they have been live in `metrics.py` since v1.1.0.
The listed metric names were also incomplete and stale.

Closes #135
Refs #131

## What

- Removed the "Not Yet Implemented" hedge
- Replaced the incomplete MCP server metrics table with the full set from `metrics.py`
  (state, cold start, discovery, HTTP transport, rate limiting)
- Label column now uses lowercase `mcp_server` matching Prometheus conventions

## How tested

- Verified each metric name against `src/mcp_hangar/metrics.py`
- `mkdocs build` passes (no broken links)

## Agent metadata

- Model: claude-opus-4
- Session: mcp-hangar docs accuracy epic