### PR TITLE
fix(docs): replace broken prerequisites with in-repo provider_math image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **docs:** remove stale "Metrics Not Yet Implemented" section from OBSERVABILITY.md; all listed metrics are live in `metrics.py` since v1.1.0 (#135)
+- **docs:** replace broken prerequisite shell commands in cookbook recipes 01 and 04 with in-repo `examples/provider_math` Docker image (#128)
 - **ci:** release notes no longer contain literal `%0A` newlines (removed legacy set-output encoding)
 - **ci:** release body no longer has a duplicated `## What's Changed` section (removed `generate_release_notes: true`); a manual Full Changelog compare link is added instead
 - **ci:** HTML entities (`&gt;`, `&lt;`, `&amp;`) in CHANGELOG entries are decoded before writing to the release body

--- a/docs/cookbook/01-http-gateway.md
+++ b/docs/cookbook/01-http-gateway.md
@@ -11,19 +11,25 @@ You have one MCP server today. Tomorrow you'll have five. You need a control pla
 
 ## Prerequisites
 
-You need a running MCP server to point Hangar at. Use any Streamable HTTP MCP server you already have, or start a test one:
+You need a running MCP server to point Hangar at. This repo ships a test
+server in `examples/provider_math/` that runs on Streamable HTTP.
 
 ```bash
-# Option A: Using npx (Node.js)
-npx -y @anthropic/mcp-server-everything --transport sse --port 8080
+# Build the test MCP server (requires Docker)
+docker build -t mcp-math:latest examples/provider_math/
+
+# Start it on port 8080
+docker run -d --name mcp-math -p 8080:8080 mcp-math:latest
 ```
+
+Verify it is running:
 
 ```bash
-# Option B: Using uvx (Python)
-uvx mcp-server-fetch --transport sse --port 8080
+curl -s http://localhost:8080/mcp -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}' \
+  -H "Content-Type: application/json" | head -c 80
 ```
 
-Keep this running in a separate terminal.
+You should see a JSON-RPC response. Keep the container running.
 
 ## The Config
 
@@ -32,7 +38,7 @@ Keep this running in a separate terminal.
 mcp_servers:
   my-mcp:
     mode: remote
-    endpoint: http://localhost:8080/sse
+    endpoint: http://localhost:8080/mcp
     description: "My remote MCP server"
     http:
       connect_timeout: 10.0
@@ -121,9 +127,17 @@ Save this as `~/.config/mcp-hangar/config.yaml` or pass it with `--config`.
 
 ## What Just Happened
 
-Hangar loaded your MCP server configuration and started in stdio mode (JSON-RPC over stdin/stdout). When you sent the `initialize` handshake, Hangar responded with its capabilities. On the first `hangar_list` call, Hangar performed a cold start: it launched the subprocess MCP server (`uvx mcp-server-fetch` in this example, or connects to remote endpoint if using `mode: remote`), sent MCP `initialize` + `tools/list` to discover available tools, and registered them in its internal registry.
+Hangar loaded your MCP server configuration and started in stdio mode (JSON-RPC over stdin/stdout). When you sent the `initialize` handshake, Hangar responded with its capabilities. On the first `hangar_list` call, Hangar performed a cold start: it connected to the remote MCP server (`examples/provider_math` in this recipe), sent MCP `initialize` + `tools/list` to discover available tools, and registered them in its internal registry.
 
 The test MCP server doesn't know Hangar exists — it sees standard MCP JSON-RPC requests. This is a transparent proxy pattern. Hangar adds nothing yet: no health checks, no circuit breaker, no authentication. That's the point — recipe 01 is the baseline.
+
+## Cleanup
+
+When you are done with this recipe (or before starting recipe 02), stop the test container:
+
+```bash
+docker rm -f mcp-math
+```
 
 ## Key Config Reference
 

--- a/docs/cookbook/04-failover.md
+++ b/docs/cookbook/04-failover.md
@@ -13,18 +13,21 @@ Your single MCP server is one crash away from downtime. What if there was a seco
 
 ## Prerequisites
 
-You need TWO running MCP servers. Start both:
+You need TWO running MCP servers. Use the in-repo test server on different
+ports:
 
 ```bash
+# Build the test MCP server (skip if already built in recipe 01)
+docker build -t mcp-math:latest examples/provider_math/
+
 # Terminal 1: Primary server on port 8080
-uvx mcp-server-fetch &
+docker run -d --name mcp-primary -p 8080:8080 mcp-math:latest
 
 # Terminal 2: Backup server on port 8081
-# (simulate by running another instance - in real world this would be a different host)
-MCP_PORT=8081 uvx mcp-server-fetch &
+docker run -d --name mcp-backup -p 8081:8080 -e MCP_PORT=8080 mcp-math:latest
 ```
 
-Keep both running.
+Keep both containers running.
 
 ## The Config
 
@@ -38,7 +41,7 @@ health_check:
 mcp_servers:
   my-mcp:
     mode: remote
-    endpoint: http://localhost:8080/sse
+    endpoint: http://localhost:8080/mcp
     description: "Primary MCP server"
     health_check_interval_s: 30
     max_consecutive_failures: 3
@@ -48,7 +51,7 @@ mcp_servers:
 
   my-mcp-backup:                           # NEW: added in this recipe
     mode: remote                           # NEW: added in this recipe
-    endpoint: http://localhost:8081/sse    # NEW: added in this recipe
+    endpoint: http://localhost:8081/mcp    # NEW: added in this recipe
     description: "Backup MCP server"       # NEW: added in this recipe
     health_check_interval_s: 30            # NEW: added in this recipe
     max_consecutive_failures: 3            # NEW: added in this recipe
@@ -124,7 +127,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
 4. Kill the primary server
 
    ```bash
-   pkill -f "mcp-server-fetch.*8080"
+   docker stop mcp-primary
    ```
 
    Primary is now dead. Backup still running.


### PR DESCRIPTION
## Why

Cookbook recipes 01 and 04 referenced upstream MCP servers (`mcp-server-fetch`,
`mcp-server-everything`) that are broken or unavailable via npx/uvx. Readers
following the recipes hit immediate failures at the first step.

Closes #128
Refs #124

## What

- Replace external package prereqs with the in-repo `examples/provider_math/`
  Docker image (always available, deterministic)
- Fix endpoint path from `/sse` to `/mcp` (Streamable HTTP, not SSE)
- Add verification curl command to confirm the server is running
- Update recipe 04 failover prereqs accordingly

## How tested

- Built `examples/provider_math/` Docker image locally
- Verified the curl initialization handshake returns a JSON-RPC response
- `mkdocs build` passes

## Agent metadata

- Model: claude-opus-4
- Session: mcp-hangar docs accuracy epic

## Risk and rollback

Documentation-only change. No runtime impact. Revert the commit to rollback.

## CHANGELOG note

- Fixed: cookbook recipes 01 and 04 now reference in-repo provider_math image instead of broken upstream packages