### PR TITLE
fix(docs): drop phantom endpoints from REST_API, WEBSOCKETS, LOG_STREAMING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs:** replace broken prerequisite shell commands in cookbook recipes 01 and 04 with in-repo `examples/provider_math` Docker image (#128)
 - **docs:** correct hangar_call format (requires `calls:[...]` array), remove phantom CLI subcommands, fix endpoint paths across cookbook recipes (#125)
 - **docs:** drop phantom config blocks (global `health_check:`, `logging:`, `metrics:`) from cookbook recipes (#126)
+- **docs:** drop phantom endpoints (Catalog, Observability, Maintenance, `/ws/state`, `/ws/logs`) from REST_API, WEBSOCKETS, and LOG_STREAMING guides; align with real router mounts and WS subscribe protocol (#132)
 - **ci:** release notes no longer contain literal `%0A` newlines (removed legacy set-output encoding)
 - **ci:** release body no longer has a duplicated `## What's Changed` section (removed `generate_release_notes: true`); a manual Full Changelog compare link is added instead
 - **ci:** HTML entities (`&gt;`, `&lt;`, `&amp;`) in CHANGELOG entries are decoded before writing to the release body

--- a/docs/guides/LOG_STREAMING.md
+++ b/docs/guides/LOG_STREAMING.md
@@ -1,6 +1,6 @@
 # Log Streaming
 
-MCP Hangar captures stderr output from subprocess and Docker MCP servers and makes it available via REST API and WebSocket for real-time log viewing.
+MCP Hangar captures stderr output from subprocess and Docker MCP servers and makes it available via REST API.
 
 ## Architecture
 
@@ -11,11 +11,9 @@ MCP Server Process (stderr)
         |
    ProviderLogBuffer (ring buffer, 1000 lines)
         |
-   +----+----+
-   |         |
-GET /logs  WebSocket /ws/mcp_servers/{id}/logs
-   |         |
- REST API  LogStreamBroadcaster
+   GET /api/mcp_servers/{id}/logs
+        |
+     REST API
 ```
 
 Each MCP server gets a dedicated `ProviderLogBuffer` -- a thread-safe ring buffer holding the most recent 1000 log lines. A background reader thread continuously reads the MCP server's stderr and appends lines to the buffer.
@@ -58,32 +56,6 @@ Returns the most recent `lines` entries from the ring buffer (default 100, max 1
 
 Returns an empty list if the MCP server exists but has no log buffer yet (MCP server not started). Returns 404 if the MCP server is not registered.
 
-## WebSocket
-
-### Live log stream
-
-```
-ws://localhost:8000/api/ws/mcp_servers/{mcp_server_id}/logs
-```
-
-Connects to a live stream of log lines for a specific MCP server. New lines are pushed as they arrive from stderr.
-
-Each message is a JSON object with the same `LogLine` format:
-
-```json
-{"timestamp": "...", "line": "...", "mcp_server_id": "math", "stream": "stderr"}
-```
-
-The WebSocket connection uses `LogStreamBroadcaster`, which registers an `on_append` callback on the MCP server's log buffer. When the buffer receives a new line, the broadcaster pushes it to all connected WebSocket clients.
-
-### Connection lifecycle
-
-1. Client connects to `/api/ws/MCP servers/{mcp_server_id}/logs`.
-2. Server validates that the MCP server exists.
-3. Server registers a broadcast callback on the log buffer.
-4. Log lines are pushed to the client as they arrive.
-5. On disconnect, the callback is deregistered.
-
 ## Configuration
 
 Log capture is automatic for subprocess and Docker MCP servers. No configuration is required.
@@ -91,22 +63,6 @@ Log capture is automatic for subprocess and Docker MCP servers. No configuration
 | Behavior | Value |
 |----------|-------|
 | Buffer size | 1000 lines per MCP server |
-| Captured stream | stderr only |
-| Buffer type | Thread-safe ring buffer |
-| Persistence | In-memory only (lost on restart) |
-
-## Client Integration
-
-Log streaming can be consumed by any HTTP/WebSocket client:
-
-1. Fetch the initial buffer contents via `GET /api/mcp_servers/{id}/logs`.
-2. Open a WebSocket connection for live updates.
-3. Handle reconnection on WebSocket disconnect.
-
-## Supported MCP Server Modes
-
-| Mode | Log Capture | Notes |
-|------|------------|-------|
-| `subprocess` | stderr via PIPE | Reader thread reads `process.stderr` |
-| `docker` | stderr via PIPE | `DockerLauncher` attaches to container stderr |
-| `remote` | Not captured | Remote MCP servers manage their own logs |
+| Line length limit | 8192 bytes (truncated with `...`) |
+| Encoding | UTF-8 with `replace` error handling |
+| Capture source | stderr only (stdout is JSON-RPC) |

--- a/docs/guides/REST_API.md
+++ b/docs/guides/REST_API.md
@@ -39,7 +39,7 @@ All endpoints return JSON. Error responses follow the envelope format:
 
 ```json
 {
-  "error": "ProviderNotFoundError",
+  "error": "McpServerNotFoundError",
   "message": "MCP Server 'unknown' not found",
   "status_code": 404
 }
@@ -91,13 +91,7 @@ All endpoints return JSON. Error responses follow the envelope format:
 
 ### Catalog
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/catalog` | List catalog entries (`?search=`, `?tags=`) |
-| `GET` | `/api/catalog/{id}` | Get a catalog entry |
-| `POST` | `/api/catalog` | Add a custom catalog entry |
-| `DELETE` | `/api/catalog/{id}` | Remove a catalog entry |
-| `POST` | `/api/catalog/{id}/deploy` | Deploy a catalog entry as a live MCP server |
+> **Not implemented.** Catalog endpoints are planned for a future release.
 
 ### Configuration
 
@@ -115,51 +109,51 @@ All endpoints return JSON. Error responses follow the envelope format:
 |--------|------|-------------|
 | `GET` | `/api/system` | System info (uptime, version, metrics summary) |
 
-### Auth Management
+### Auth Management (Enterprise)
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/api/auth/keys` | Create an API key |
+| `GET` | `/api/auth/keys` | List API keys |
 | `DELETE` | `/api/auth/keys/{key_id}` | Revoke an API key |
-| `GET` | `/api/auth/keys/{principal_id}` | List keys for a principal |
-| `GET` | `/api/auth/roles` | List all roles |
-| `GET` | `/api/auth/roles/builtin` | List built-in roles |
-| `GET` | `/api/auth/roles/{role_id}` | Get role details |
+| `GET` | `/api/auth/roles` | List roles |
 | `POST` | `/api/auth/roles` | Create a custom role |
-| `PUT` | `/api/auth/roles/{role_id}` | Update a custom role |
-| `DELETE` | `/api/auth/roles/{role_id}` | Delete a custom role |
-| `POST` | `/api/auth/principals/{id}/roles` | Assign a role to a principal |
-| `DELETE` | `/api/auth/principals/{id}/roles/{role_id}` | Revoke a role |
+| `GET` | `/api/auth/roles/all` | List all roles (including built-in) |
+| `POST` | `/api/auth/roles/assign` | Assign a role to a principal |
+| `DELETE` | `/api/auth/roles/revoke` | Revoke a role from a principal |
+| `GET` | `/api/auth/roles/{role_name}` | Get role details |
+| `DELETE` | `/api/auth/roles/{role_name}` | Delete a custom role |
+| `PATCH` | `/api/auth/roles/{role_name}` | Update a custom role |
 | `GET` | `/api/auth/principals` | List principals |
-| `GET` | `/api/auth/principals/{id}/roles` | List roles for a principal |
+| `GET` | `/api/auth/principals/roles` | Get roles for a principal |
+| `GET` | `/api/auth/permissions` | List all permissions |
 | `POST` | `/api/auth/check-permission` | Check if a principal has permission |
-| `GET` | `/api/auth/policies/{MCP server}/{tool}` | Get tool access policy |
-| `PUT` | `/api/auth/policies/{MCP server}/{tool}` | Set tool access policy |
-| `DELETE` | `/api/auth/policies/{MCP server}/{tool}` | Clear tool access policy |
+| `GET` | `/api/auth/policies/{scope}/{target_id}` | Get tool access policy |
+| `POST` | `/api/auth/policies/{scope}/{target_id}` | Set tool access policy |
+| `DELETE` | `/api/auth/policies/{scope}/{target_id}` | Clear tool access policy |
 
 ### Observability
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/observability/metrics` | Prometheus metrics + JSON summary |
-| `GET` | `/api/observability/audit` | Audit log (`?mcp_server_id=`, `?event_type=`, `?limit=`) |
-| `GET` | `/api/observability/security` | Security events |
-| `GET` | `/api/observability/alerts` | Alert history (`?level=`) |
-| `GET` | `/api/observability/metrics/history` | Time-series metrics snapshots |
+> **Not mounted as a dedicated route group.** Metrics are served at `/metrics`
+> (outside the `/api/` prefix). Audit/security events use the domain event bus
+> and are available via the `/api/ws/events` WebSocket stream.
 
-### Maintenance
+### Health Probes
+
+These endpoints are outside the `/api/` prefix and skip authentication:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/maintenance/compact` | Compact an event stream |
+| `GET` | `/health/live` | Liveness probe |
+| `GET` | `/health/ready` | Readiness probe |
+| `GET` | `/health/startup` | Startup probe |
+| `GET` | `/metrics` | Prometheus metrics |
 
 ### WebSockets
 
 | Path | Description |
 |------|-------------|
-| `/api/ws/events` | Real-time domain event stream |
-| `/api/ws/state` | MCP server state change stream |
-| `/api/ws/MCP servers/{id}/logs` | Live log stream for a MCP server |
+| `/api/ws/events` | Real-time domain event stream (filterable) |
 
 See the [WebSockets guide](WEBSOCKETS.md) for connection details.
 
@@ -246,7 +240,7 @@ All domain exceptions are mapped to HTTP status codes:
 
 | Exception | Status Code |
 |-----------|-------------|
-| `ProviderNotFoundError` | 404 |
+| `McpServerNotFoundError` | 404 |
 | `ValidationError` | 422 |
 | `RateLimitExceeded` | 429 |
 | `CompactionError` | 500 |

--- a/docs/guides/WEBSOCKETS.md
+++ b/docs/guides/WEBSOCKETS.md
@@ -1,30 +1,20 @@
 # WebSockets
 
-MCP Hangar provides WebSocket endpoints for real-time streaming of domain events, MCP server state changes, and MCP server logs.
+MCP Hangar provides a WebSocket endpoint for real-time streaming of domain events.
 
-## Endpoints
-
-All WebSocket endpoints are mounted under `/api/ws/`:
+## Endpoint
 
 | Endpoint | Description |
 |----------|-------------|
-| `/api/ws/events` | All domain events |
-| `/api/ws/state` | MCP server state changes only |
-| `/api/ws/MCP servers/{id}/logs` | Live stderr log stream for a MCP server |
+| `/api/ws/events` | All domain events (filterable via subscribe message) |
 
 ## Connecting
 
-Use any WebSocket client. Examples with `websocat`:
+Use any WebSocket client. Example with `websocat`:
 
 ```bash
 # Stream all domain events
 websocat ws://localhost:8000/api/ws/events
-
-# Stream state changes only
-websocat ws://localhost:8000/api/ws/state
-
-# Stream logs for a specific mcp_server
-websocat ws://localhost:8000/api/ws/mcp_servers/math/logs
 ```
 
 ## Event Stream (`/api/ws/events`)
@@ -57,117 +47,49 @@ All events from `domain/events.py` are published:
 
 ### Filtering
 
-The events endpoint supports optional query parameters for filtering:
-
-```
-ws://localhost:8000/api/ws/events?mcp_server_id=math
-ws://localhost:8000/api/ws/events?event_type=McpServerStateChanged
-```
-
-## State Stream (`/api/ws/state`)
-
-A filtered view of the event stream that only includes `McpServerStateChanged` events:
+After connecting, send a JSON `subscribe` message to filter events:
 
 ```json
 {
-  "event_type": "McpServerStateChanged",
-  "mcp_server_id": "math",
-  "old_state": "COLD",
-  "new_state": "INITIALIZING",
-  "timestamp": "2026-03-23T10:15:30.123456"
+  "type": "subscribe",
+  "event_types": ["McpServerStateChanged"],
+  "mcp_server_ids": ["math"]
 }
 ```
 
-This endpoint can be used by clients to update MCP server state in real-time without polling.
-
-## Log Stream (`/api/ws/MCP servers/{id}/logs`)
-
-Streams stderr log lines for a specific MCP server. See the [Log Streaming guide](LOG_STREAMING.md) for details.
+The server acknowledges with:
 
 ```json
 {
-  "timestamp": "2026-03-23T10:15:30.123456",
-  "line": "INFO: Processing request...",
-  "mcp_server_id": "math",
-  "stream": "stderr"
+  "type": "subscribed",
+  "event_types": ["McpServerStateChanged"],
+  "mcp_server_ids": ["math"]
 }
 ```
 
-## Connection Management
+You can update filters at any time by sending another `subscribe` message. Omit a key to not filter on that dimension (e.g., omit `mcp_server_ids` to receive events from all MCP servers).
 
-### WebSocket Manager
+## Queue and Backpressure
 
-The `WebSocketManager` in `server/api/ws/manager.py` tracks all active connections. It provides:
-
-- **Connection registry** -- Tracks active WebSocket connections per endpoint.
-- **Broadcast** -- Publishes events to all connected clients for an endpoint.
-- **Cleanup** -- Removes disconnected clients automatically.
-
-### Event Bus Integration
-
-The WebSocket layer subscribes to the `EventBus` for domain events. On server shutdown, subscriptions are cleaned up via `EventBus.unsubscribe_from_all()`.
-
-### Queue and Backpressure
-
-Each WebSocket connection has an internal message queue (`WebSocketQueue`). If a client falls behind:
+Each WebSocket connection has an internal message queue (`EventStreamQueue`). If a client falls behind:
 
 1. Messages queue up to the buffer limit.
 2. Beyond the limit, oldest messages are dropped.
 3. The client receives a warning frame indicating dropped messages.
 
-## Client Integration
+## Authentication
 
-WebSocket endpoints can be consumed by any WebSocket client:
+When auth is enabled, pass credentials via the initial HTTP upgrade headers:
 
-### Example: `useWebSocket`
-
-Base hook with exponential backoff reconnection:
-
-```typescript
-const { isConnected, lastMessage } = useWebSocket('/api/ws/events');
+```bash
+websocat "ws://localhost:8000/api/ws/events" -H "X-API-Key: mcp_your_key_here"
 ```
 
-Features:
+## Connection Lifecycle
 
-- Automatic reconnection with exponential backoff (1s, 2s, 4s, ... up to 30s).
-- Connection state tracking.
-- Message deserialization from JSON.
-
-### `useEventStream`
-
-High-level hook for the events endpoint:
-
-```typescript
-const { events } = useEventStream({ providerFilter: 'math' });
-```
-
-### `useMcpServerState`
-
-Connects to the state endpoint and maintains a local map of MCP server states:
-
-```typescript
-const { providerStates } = useMcpServerState();
-// providerStates: Record<string, McpServerState>
-```
-
-### `useProviderLogs`
-
-Combines REST fetch with WebSocket for live logs:
-
-```typescript
-const { logs, isConnected } = useProviderLogs('math');
-```
-
-## State Management
-
-WebSocket connection state is managed by a Zustand store (`src/store/websocket.ts`):
-
-```typescript
-interface WebSocketStore {
-  connections: Record<string, WebSocketConnection>;
-  connect: (url: string) => void;
-  disconnect: (url: string) => void;
-}
-```
-
-This enables clients to track connection status and reconnect all WebSocket connections after a network interruption.
+1. Client sends WebSocket upgrade to `/api/ws/events`.
+2. Server accepts the connection.
+3. (Optional) Client sends a `subscribe` message to set filters.
+4. Server streams matching events as JSON messages.
+5. Client can send updated `subscribe` messages at any time.
+6. On disconnect, the subscription is cleaned up automatically.


### PR DESCRIPTION
## Why

The REST_API, WEBSOCKETS, and LOG_STREAMING guides documented endpoints that
do not exist in the codebase: `/api/catalog/*`, `/api/observability/*`,
`/api/maintenance/*`, `/api/ws/state`, `/api/ws/mcp_servers/{id}/logs`. They
also described query-param-based WS filtering when the real implementation uses
a JSON `subscribe` message protocol.

Closes #132
Refs #131

## What

- **REST_API.md**: Remove Catalog, Observability, Maintenance route tables;
  add Health Probes section (`/health/live|ready|startup`, `/metrics`); fix
  Auth Management to match real enterprise routes; reduce WebSockets table to
  single `/api/ws/events` entry; fix error class name
- **WEBSOCKETS.md**: Full rewrite -- single `/events` endpoint, JSON subscribe
  protocol, EventStreamQueue backpressure; removed phantom `/state` and `/logs`
  endpoints plus frontend TypeScript/Zustand sections
- **LOG_STREAMING.md**: Removed WebSocket architecture branch and
  `LogStreamBroadcaster`; kept REST-only architecture

## How tested

- Verified routes against `src/mcp_hangar/server/api/router.py` (9 mounts)
- Verified WS protocol against `src/mcp_hangar/server/api/ws/events.py`
- Verified health/metrics against `src/mcp_hangar/server/lifecycle.py`
- Verified auth routes against `enterprise/auth/api/routes.py`

## Agent metadata

- Model: claude-opus-4
- Session: mcp-hangar docs accuracy epic

## Risk and rollback

Documentation-only change. No runtime impact. Revert the commit to rollback.

## CHANGELOG note

- Fixed: REST_API, WEBSOCKETS, and LOG_STREAMING guides now reflect actual implemented endpoints