### PR TITLE
fix(docs): add cross-repo operator prerequisites for Kubernetes recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs:** correct hangar_call format (requires `calls:[...]` array), remove phantom CLI subcommands, fix endpoint paths across cookbook recipes (#125)
 - **docs:** drop phantom config blocks (global `health_check:`, `logging:`, `metrics:`) from cookbook recipes (#126)
 - **docs:** drop phantom endpoints (Catalog, Observability, Maintenance, `/ws/state`, `/ws/logs`) from REST_API, WEBSOCKETS, and LOG_STREAMING guides; align with real router mounts and WS subscribe protocol (#132)
+- **docs:** add cross-repo operator prerequisites for Kubernetes recipes 11, 13, and KUBERNETES guide; link to `mcp-hangar/hangar-operator` and fix Helm/CRD URLs (#127)
 - **ci:** release notes no longer contain literal `%0A` newlines (removed legacy set-output encoding)
 - **ci:** release body no longer has a duplicated `## What's Changed` section (removed `generate_release_notes: true`); a manual Full Changelog compare link is added instead
 - **ci:** HTML entities (`&gt;`, `&lt;`, `&amp;`) in CHANGELOG entries are decoded before writing to the release body

--- a/docs/cookbook/11-discovery-kubernetes.md
+++ b/docs/cookbook/11-discovery-kubernetes.md
@@ -5,6 +5,32 @@
 > **Time:** 15 minutes
 > **Adds:** Auto-discover MCP servers from Kubernetes annotations
 
+## Prerequisites
+
+This recipe requires the **MCP-Hangar Operator** running in your cluster.
+The operator ships from a separate repository:
+<https://github.com/mcp-hangar/hangar-operator>.
+
+Install via Helm (from the [helm-charts](https://github.com/mcp-hangar/helm-charts) repo):
+
+```bash
+helm repo add mcp-hangar https://mcp-hangar.github.io/helm-charts
+helm repo update
+helm install mcp-hangar-operator mcp-hangar/mcp-hangar-operator \
+  --namespace mcp-system \
+  --create-namespace
+```
+
+Verify the CRDs are installed:
+
+```bash
+kubectl get crd | grep mcp-hangar.io
+# Expected:
+#   mcpservers.mcp-hangar.io
+#   mcpservergroups.mcp-hangar.io
+#   mcpdiscoverysources.mcp-hangar.io
+```
+
 ## The Problem
 
 You run MCP servers as Kubernetes services. Teams deploy and scale MCP servers independently. You need Hangar to discover them from annotations without manual config updates.

--- a/docs/cookbook/13-production-checklist.md
+++ b/docs/cookbook/13-production-checklist.md
@@ -51,7 +51,11 @@
 
 ## Kubernetes (if applicable)
 
-- [ ] MCP-Hangar Operator installed
+> The MCP-Hangar Operator is an external component shipped from
+> [hangar-operator](https://github.com/mcp-hangar/hangar-operator).
+> See [Recipe 11](11-discovery-kubernetes.md#prerequisites) for install instructions.
+
+- [ ] MCP-Hangar Operator installed (see [Recipe 11 prerequisites](11-discovery-kubernetes.md#prerequisites))
 - [ ] CRDs applied (`MCPServer`, `MCPServerGroup`, `MCPDiscoverySource`)
 - [ ] RBAC (Kubernetes) configured for operator service account
 - [ ] Network policies restricting MCP server-to-MCP server communication

--- a/docs/guides/KUBERNETES.md
+++ b/docs/guides/KUBERNETES.md
@@ -2,6 +2,10 @@
 
 Deploy and manage MCP servers as native Kubernetes resources using the MCP-Hangar Operator.
 
+> **The MCP-Hangar Operator is shipped from a separate repository:
+> [hangar-operator](https://github.com/mcp-hangar/hangar-operator).**
+> Helm charts live in [helm-charts](https://github.com/mcp-hangar/helm-charts).
+
 ## Overview
 
 The MCP-Hangar Operator provides:
@@ -20,11 +24,14 @@ The MCP-Hangar Operator provides:
 
 ### Install CRDs
 
+CRDs are bundled with the operator. They are installed automatically by the Helm
+chart. To install manually:
+
 ```bash
-# Install Custom Resource Definitions
-kubectl apply -f https://raw.githubusercontent.com/mcp-hangar/mcp-hangar/main/deploy/crds/mcpserver.yaml
-kubectl apply -f https://raw.githubusercontent.com/mcp-hangar/mcp-hangar/main/deploy/crds/mcpservergroup.yaml
-kubectl apply -f https://raw.githubusercontent.com/mcp-hangar/mcp-hangar/main/deploy/crds/mcpdiscoverysource.yaml
+# Install Custom Resource Definitions (from the operator repo)
+kubectl apply -f https://raw.githubusercontent.com/mcp-hangar/hangar-operator/main/deploy/crds/mcpserver.yaml
+kubectl apply -f https://raw.githubusercontent.com/mcp-hangar/hangar-operator/main/deploy/crds/mcpservergroup.yaml
+kubectl apply -f https://raw.githubusercontent.com/mcp-hangar/hangar-operator/main/deploy/crds/mcpdiscoverysource.yaml
 
 # Verify
 kubectl get crds | grep mcp-hangar.io
@@ -34,7 +41,7 @@ kubectl get crds | grep mcp-hangar.io
 
 ```bash
 # Add Helm repository
-helm repo add mcp-hangar https://mcp-hangar.io/charts
+helm repo add mcp-hangar https://mcp-hangar.github.io/helm-charts
 helm repo update
 
 # Install operator


### PR DESCRIPTION
## Why

Recipes 11 and 13, plus the KUBERNETES.md guide, reference the MCP-Hangar
Operator and its CRDs as if they ship from this repo. They live in the sibling
repo `mcp-hangar/hangar-operator`. A reader on a fresh checkout cannot apply
the YAML without installing the operator first.

Closes #127
Refs #124

## What

- **Recipe 11**: Add `## Prerequisites` section with Helm install from
  `mcp-hangar/helm-charts`, CRD verification command
- **Recipe 13**: Add blockquote noting operator is external; link to recipe 11
  prerequisites
- **KUBERNETES.md**: Add callout linking to `hangar-operator` and `helm-charts`
  repos; fix CRD URLs to point at operator repo; fix Helm repo URL from
  `mcp-hangar.io/charts` to `mcp-hangar.github.io/helm-charts`

## How tested

- Verified repos exist via `gh api orgs/mcp-hangar/repos`
- Links validated manually
- `mkdocs build` passes

## Agent metadata

- Model: claude-opus-4
- Session: mcp-hangar docs accuracy epic

## Risk and rollback

Documentation-only change. No runtime impact. Revert the commit to rollback.

## CHANGELOG note

- Fixed: Kubernetes recipes now include correct operator and Helm chart repository prerequisites