### PR TITLE
fix(docs): drop phantom CLI subcommands and fix stale metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **docs:** add cross-repo operator prerequisites for Kubernetes recipes 11, 13, and KUBERNETES guide; link to `mcp-hangar/hangar-operator` and fix Helm/CRD URLs (#127)
 - **docs:** rename `09-subprocess-providers.md` to `09-subprocess-mcp-servers.md`, fix `TracedProviderService` reference in recipe 08, update nav (#129)
 - **docs:** clean up Provider to McpServer artifacts in guides: rename PROVIDER_GROUPS.md, fix class names (ProviderInfo, ProviderNotFoundError, TracedProviderService), fix code-fence field names (#133)
+- **docs:** drop phantom `mcp-hangar auth` CLI subcommands from AUTHENTICATION.md (replace with REST API equivalents), fix stale metric suffixes in BATCH_INVOCATIONS.md and DISCOVERY.md, remove phantom `mcp-hangar mcp_server start` from OBSERVABILITY.md (#134)
 - **ci:** release notes no longer contain literal `%0A` newlines (removed legacy set-output encoding)
 - **ci:** release body no longer has a duplicated `## What's Changed` section (removed `generate_release_notes: true`); a manual Full Changelog compare link is added instead
 - **ci:** HTML entities (`&gt;`, `&lt;`, `&amp;`) in CHANGELOG entries are decoded before writing to the release body

--- a/docs/guides/AUTHENTICATION.md
+++ b/docs/guides/AUTHENTICATION.md
@@ -22,16 +22,22 @@ auth:
 ### 2. Create an API Key
 
 ```bash
-# Using CLI (once implemented)
-mcp-hangar auth create-key \
-  --principal "service:my-app" \
-  --name "My App Key" \
-  --role developer
+# Via the REST API (there is no auth CLI subcommand)
+curl -X POST http://localhost:8000/api/auth/keys \
+  -H "X-API-Key: <admin-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principal": "service:my-app",
+    "name": "My App Key",
+    "role": "developer"
+  }'
 
-# Output:
-# API Key created for service:my-app
-# Key: mcp_aBcDeFgHiJkLmNoPqRsTuVwXyZ...
-# ⚠️  Save this key now - it cannot be retrieved later!
+# Response:
+# {
+#   "key": "mcp_aBcDeFgHiJkLmNoPqRsTuVwXyZ...",
+#   "principal": "service:my-app"
+# }
+# Save this key now - it cannot be retrieved later!
 ```
 
 ### 3. Use the API Key
@@ -114,13 +120,17 @@ auth:
       scope: "tenant:data-team"
 ```
 
-#### Dynamic (via CLI)
+#### Dynamic (via REST API)
 
 ```bash
-mcp-hangar auth assign-role \
-  --principal "user:john@company.com" \
-  --role developer \
-  --scope global
+curl -X POST http://localhost:8000/api/auth/roles/assign \
+  -H "X-API-Key: <admin-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principal": "user:john@company.com",
+    "role": "developer",
+    "scope": "global"
+  }'
 ```
 
 ## Security Best Practices
@@ -131,11 +141,15 @@ Always use HTTPS for MCP endpoints in production. The auth system will warn if O
 
 ### 2. Configure Trusted Proxies
 
-If behind a load balancer, configure trusted proxies for correct client IP detection:
+If behind a load balancer, configure trusted proxies for correct client IP detection.
+Trusted proxies are set programmatically via `FastMCPServerConfig`:
 
-```yaml
-# In ServerConfig or via builder
-trusted_proxies: ["10.0.0.0/8", "172.16.0.0/12"]
+```python
+from mcp_hangar.fastmcp_server.config import FastMCPServerConfig
+
+config = FastMCPServerConfig(
+    trusted_proxies=frozenset(["10.0.0.0/8", "172.16.0.0/12"]),
+)
 ```
 
 ### 3. Rotate API Keys Regularly
@@ -143,10 +157,14 @@ trusted_proxies: ["10.0.0.0/8", "172.16.0.0/12"]
 Set expiration for API keys and rotate them periodically:
 
 ```bash
-mcp-hangar auth create-key \
-  --principal "service:ci" \
-  --name "CI Pipeline Key" \
-  --expires 30  # Expires in 30 days
+curl -X POST http://localhost:8000/api/auth/keys \
+  -H "X-API-Key: <admin-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principal": "service:ci",
+    "name": "CI Pipeline Key",
+    "expires_in_days": 30
+  }'
 ```
 
 ### 4. Use Tenant Isolation
@@ -188,7 +206,7 @@ These are logged and can be sent to your observability stack.
 ### "Access denied"
 
 - The principal doesn't have the required role
-- Check role assignments with `mcp-hangar auth list-roles`
+- Check role assignments via the REST API (`GET /api/auth/roles`)
 - Verify the scope matches
 
 ## API Reference

--- a/docs/guides/BATCH_INVOCATIONS.md
+++ b/docs/guides/BATCH_INVOCATIONS.md
@@ -292,9 +292,9 @@ Prometheus metrics for batch operations:
 
 ```
 mcp_hangar_batch_calls_total{result="success|partial|failure|validation_error"}
-mcp_hangar_batch_size_histogram{}
-mcp_hangar_batch_duration_seconds{}
-mcp_hangar_batch_concurrency_gauge{}
+mcp_hangar_batch_size_bucket{}
+mcp_hangar_batch_duration_seconds_bucket{}
+mcp_hangar_batch_concurrency{}
 mcp_hangar_batch_truncations_total{reason="per_call|total_size"}
 mcp_hangar_batch_circuit_breaker_rejections_total{mcp_server="..."}
 mcp_hangar_batch_cancellations_total{reason="timeout|fail_fast"}
@@ -330,7 +330,7 @@ If you were using the previous tools, here's how to migrate:
 1. **Use retry for external calls** - Set `max_retries=3` for fetch, database, and network operations
 2. **Group related calls** - Batch calls that can run independently
 3. **Set appropriate timeouts** - Use per-call timeouts for varying workloads
-4. **Monitor metrics** - Watch `batch_duration_seconds` and `batch_size_histogram`
+4. **Monitor metrics** - Watch `mcp_hangar_batch_duration_seconds` and `mcp_hangar_batch_size`
 5. **Handle partial failures** - Check `succeeded` and `failed` counts
 6. **Use fail-fast sparingly** - Only when all-or-nothing is required
 

--- a/docs/guides/DISCOVERY.md
+++ b/docs/guides/DISCOVERY.md
@@ -158,7 +158,7 @@ discovery:
 
 | Metric | Description |
 |--------|-------------|
-| `mcp_hangar_discovery_providers_total` | MCP servers per source |
+| `mcp_hangar_discovery_mcp_servers` | MCP servers per source (Gauge) |
 | `mcp_hangar_discovery_registrations_total` | New registrations |
 | `mcp_hangar_discovery_errors_total` | Errors by source |
-| `mcp_hangar_discovery_latency_seconds` | Cycle duration |
+| `mcp_hangar_discovery_cycle_duration_seconds` | Cycle duration (Histogram) |

--- a/docs/guides/OBSERVABILITY.md
+++ b/docs/guides/OBSERVABILITY.md
@@ -704,10 +704,11 @@ If `MCPHangarHighConsecutiveFailures` fires:
 
 1. Check MCP server logs for errors
 2. Verify MCP server command/configuration
-3. Test MCP server manually:
+3. Restart the MCP server by restarting Hangar or invoking the MCP server
+   (the first tool call triggers a cold start):
 
    ```bash
-   mcp-hangar mcp_server start <mcp-server-id>
+   mcp-hangar status
    ```
 
 ### MCP Server Start Errors


### PR DESCRIPTION
## Why

AUTHENTICATION.md documented `mcp-hangar auth` CLI subcommands that do not
exist (real CLI surface: init, add, remove, serve, status, completion).
BATCH_INVOCATIONS.md and DISCOVERY.md used incorrect metric name suffixes
(`_histogram`, `_gauge`, `_latency_seconds`). OBSERVABILITY.md referenced a
phantom `mcp-hangar mcp_server start` command.

Closes #134
Refs #131

## What

- **AUTHENTICATION.md**: Replace all `mcp-hangar auth` CLI samples with REST
  API equivalents (`POST /api/auth/keys`, `POST /api/auth/roles/assign`); fix
  `trusted_proxies` docs to show programmatic `FastMCPServerConfig` usage
- **BATCH_INVOCATIONS.md**: Fix metric names (`_histogram` -> `_bucket`,
  `_gauge` -> bare gauge name); update best-practices references
- **DISCOVERY.md**: Fix `mcp_hangar_discovery_providers_total` ->
  `mcp_hangar_discovery_mcp_servers` (Gauge); fix
  `mcp_hangar_discovery_latency_seconds` ->
  `mcp_hangar_discovery_cycle_duration_seconds` (Histogram)
- **OBSERVABILITY.md**: Replace phantom `mcp-hangar mcp_server start` with
  `mcp-hangar status`

## How tested

- Verified CLI surface against `src/mcp_hangar/server/cli/main.py:127`
- Verified metric names against `src/mcp_hangar/metrics.py`
- Verified auth routes against `enterprise/auth/api/routes.py`
- Verified `FastMCPServerConfig.trusted_proxies` field exists

## Agent metadata

- Model: claude-opus-4
- Session: mcp-hangar docs accuracy epic

## Risk and rollback

Documentation-only change. No runtime impact. Revert the commit to rollback.

## CHANGELOG note

- Fixed: guides no longer reference phantom CLI subcommands; metric names match actual code