### PR TITLE
fix(observability): restore set_tracer_provider call broken by global rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **observability:** restore `trace.set_tracer_provider()` call in `observability/tracing.py:214`; global Provider→McpServer rename had renamed a third-party OpenTelemetry SDK function to `set_tracer_mcp_server`, which does not exist. Tracing initialization had been failing silently in every 1.0.x and 1.1.0 build (fault barrier swallowed the AttributeError and logged at ERROR). Discovered via live smoke test of v1.1.0 in docker-compose.
 - **docs:** remove stale "Metrics Not Yet Implemented" section from OBSERVABILITY.md; all listed metrics are live in `metrics.py` since v1.1.0 (#135)
 - **docs:** replace broken prerequisite shell commands in cookbook recipes 01 and 04 with in-repo `examples/provider_math` Docker image (#128)
 - **docs:** correct hangar_call format (requires `calls:[...]` array), remove phantom CLI subcommands, fix endpoint paths across cookbook recipes (#125)

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -210,8 +210,8 @@ def init_tracing(
             logger.warning("tracing_no_exporters_configured")
             return False
 
-        # Set global tracer mcp_server
-        trace.set_tracer_mcp_server(_tracer_mcp_server)
+        # Register the global tracer provider (third-party OTel API)
+        trace.set_tracer_provider(_tracer_mcp_server)
         _initialized = True
 
         logger.info(


### PR DESCRIPTION
## Why

Over-aggressive `Provider → McpServer` global rename renamed a **third-party OpenTelemetry SDK function**. `opentelemetry.trace` exposes `set_tracer_provider()`; the renamed name `set_tracer_mcp_server` does not exist anywhere.

Every tracing initialization in every shipped 1.0.x and 1.1.0 build fails silently with:

```
module 'opentelemetry.trace' has no attribute 'set_tracer_mcp_server'
```

The fault barrier at line 224 catches `AttributeError` and logs `tracing_initialization_failed` at ERROR. No startup crash, no test failure, but **all OTLP / Langfuse / Jaeger tracing is off**. Discovered during the live v1.1.0 smoke test in docker-compose: `docker logs mcp-hangar | grep ERROR` immediately showed the issue.

Refs: Provider→McpServer rename starting at commit `e4aa6db`.

## What

- [`observability/tracing.py:214`](src/mcp_hangar/observability/tracing.py#L214) — restore `trace.set_tracer_provider(_tracer_mcp_server)` from the renamed `trace.set_tracer_mcp_server(...)`. Comment updated to call out that this is a third-party OTel API call.
- The local variable `_tracer_mcp_server` is intentionally left as-is (it holds a `TracerProvider` instance; the misleading variable name is a follow-up cleanup, not a hot-fix concern).

## How tested

- Manual: rebuilt docker-compose image with the fix and verified `tracing_initialization_failed` ERROR no longer appears in `docker logs mcp-hangar`. Tracing init reaches `tracing_no_exporters_configured` warning (expected when OTLP env vars aren't set) instead of the previous AttributeError.
- Existing unit tests in `tests/unit/observability/test_tracing.py` continue to pass — they stub `opentelemetry.trace` entirely, which is exactly why this regression slipped through CI.

## Risk and rollback

- Risk: trivial. Two characters changed in a single function call. The renamed function did nothing (raised AttributeError caught by fault barrier), so restoring the canonical name only adds working tracing where there was none.
- Rollback: revert this single commit. The system returns to the prior state of silent tracing failure.

## CHANGELOG note

Added under `## [Unreleased] > ### Fixed`:

> **observability:** restore `trace.set_tracer_provider()` call in `observability/tracing.py:214`; global Provider→McpServer rename had renamed a third-party OpenTelemetry SDK function to `set_tracer_mcp_server`, which does not exist. Tracing initialization had been failing silently in every 1.0.x and 1.1.0 build (fault barrier swallowed the AttributeError and logged at ERROR). Discovered via live smoke test of v1.1.0 in docker-compose.

## Follow-up

A separate concern surfaced during the same smoke test: the health-check worker registered the math provider but emitted no health-check events after 3 minutes of uptime, even though the tick interval is 60s. To be re-tested after this fix lands, since broken tracing may have been affecting the worker's span context manager and breaking dispatch downstream. If it persists after the fix, that's a separate bug worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)