### PR TITLE
fix(core): register interceptors/list route on bootstrap FastMCP instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** register `/interceptors/list` custom HTTP route on the bootstrap FastMCP instance so the endpoint is reachable at runtime; previously registered only on the factory's instance which is not served by `ServerLifecycle` (#151)
 - **observability:** restore `trace.set_tracer_provider()` call in `observability/tracing.py:214`; global Provider→McpServer rename had renamed a third-party OpenTelemetry SDK function to `set_tracer_mcp_server`, which does not exist. Tracing initialization had been failing silently in every 1.0.x and 1.1.0 build (fault barrier swallowed the AttributeError and logged at ERROR). Discovered via live smoke test of v1.1.0 in docker-compose.
 - **docs:** remove stale "Metrics Not Yet Implemented" section from OBSERVABILITY.md; all listed metrics are live in `metrics.py` since v1.1.0 (#135)
 - **docs:** replace broken prerequisite shell commands in cookbook recipes 01 and 04 with in-repo `examples/provider_math` Docker image (#128)

--- a/docs/architecture/INTERCEPTOR_FRAMEWORK.md
+++ b/docs/architecture/INTERCEPTOR_FRAMEWORK.md
@@ -62,7 +62,11 @@ EventBus.publish()
 
 ### Interceptor Discoverability
 
-`GET /interceptors/list` returns mcp-hangar's capabilities as a SEP-1763 interceptor:
+`GET /interceptors/list` returns mcp-hangar's capabilities as a SEP-1763 interceptor.
+This is exposed as a plain HTTP endpoint (not a JSON-RPC method) because the MCP
+Python SDK does not yet support custom JSON-RPC method registration for non-standard
+methods. Once SDK support lands, this should migrate to a JSON-RPC `interceptors/list`
+method per SEP-1763 (PR #2624).
 
 ```json
 {
@@ -70,12 +74,18 @@ EventBus.publish()
     {
       "name": "mcp-hangar",
       "version": "<package version>",
-      "types": ["validator", "mutator", "observer"],
-      "capabilities": {
-        "failOpen": true,
-        "auditMode": true,
-        "trustBoundaryAware": true
-      }
+      "type": "validator",
+      "supportedEvents": ["tools/call", "tools/list"],
+      "modes": ["audit", "enforce"],
+      "trustBoundary": "host"
+    },
+    {
+      "name": "mcp-hangar",
+      "version": "<package version>",
+      "type": "mutator",
+      "supportedEvents": ["tools/call"],
+      "modes": ["enforce"],
+      "trustBoundary": "host"
     }
   ]
 }

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -325,9 +325,9 @@ class MCPServerFactory:
 
     @staticmethod
     def _register_interceptors_list(mcp: FastMCP) -> None:
-        from .interceptors_list import interceptors_list_handler
+        from .interceptors_list import register_interceptors_list
 
-        mcp.custom_route("/interceptors/list", methods=["GET"], name="interceptors_list")(interceptors_list_handler)
+        register_interceptors_list(mcp)
 
     def _run_readiness_checks(self) -> dict[str, Any]:
         """Run readiness checks.

--- a/src/mcp_hangar/fastmcp_server/interceptors_list.py
+++ b/src/mcp_hangar/fastmcp_server/interceptors_list.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mcp.server.fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
@@ -43,3 +44,8 @@ def interceptors_list_response() -> dict[str, Any]:
 async def interceptors_list_handler(request: Request) -> JSONResponse:
     """Handle ``GET /interceptors/list``."""
     return JSONResponse(interceptors_list_response())
+
+
+def register_interceptors_list(mcp: FastMCP) -> None:
+    """Register the ``/interceptors/list`` custom HTTP route on *mcp*."""
+    mcp.custom_route("/interceptors/list", methods=["GET"], name="interceptors_list")(interceptors_list_handler)

--- a/src/mcp_hangar/server/bootstrap/tools.py
+++ b/src/mcp_hangar/server/bootstrap/tools.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 
 
 def register_all_tools(mcp_server: FastMCP) -> None:
-    """Register all MCP tools on the server.
+    """Register all MCP tools and custom HTTP routes on the server.
 
     Args:
         mcp_server: FastMCP server instance.
@@ -31,4 +31,9 @@ def register_all_tools(mcp_server: FastMCP) -> None:
     register_group_tools(mcp_server)
     register_batch_tools(mcp_server)
     register_continuation_tools(mcp_server)
+
+    from ...fastmcp_server.interceptors_list import register_interceptors_list
+
+    register_interceptors_list(mcp_server)
+
     logger.info("mcp_tools_registered")

--- a/tests/unit/test_interceptors_list.py
+++ b/tests/unit/test_interceptors_list.py
@@ -5,14 +5,16 @@ from starlette.testclient import TestClient
 from starlette.applications import Starlette
 from starlette.routing import Route
 
+from mcp.server.fastmcp import FastMCP
+
 from mcp_hangar.fastmcp_server.interceptors_list import (
     interceptors_list_handler,
     interceptors_list_response,
+    register_interceptors_list,
 )
 
 
 class TestInterceptorsListResponse:
-
     def test_response_shape(self):
         data = interceptors_list_response()
         assert "interceptors" in data
@@ -41,12 +43,13 @@ class TestInterceptorsListResponse:
 
 
 class TestInterceptorsListEndpoint:
-
     @pytest.fixture()
     def client(self) -> TestClient:
-        app = Starlette(routes=[
-            Route("/interceptors/list", interceptors_list_handler, methods=["GET"]),
-        ])
+        app = Starlette(
+            routes=[
+                Route("/interceptors/list", interceptors_list_handler, methods=["GET"]),
+            ]
+        )
         return TestClient(app)
 
     def test_get_returns_200(self, client: TestClient):
@@ -62,3 +65,26 @@ class TestInterceptorsListEndpoint:
     def test_post_not_allowed(self, client: TestClient):
         resp = client.post("/interceptors/list")
         assert resp.status_code == 405
+
+
+class TestRegisterInterceptorsList:
+    def test_register_adds_one_custom_route(self):
+        mcp = FastMCP("test-interceptors")
+        before = len(mcp._custom_starlette_routes)
+        register_interceptors_list(mcp)
+        assert len(mcp._custom_starlette_routes) == before + 1
+
+    def test_registered_route_path(self):
+        mcp = FastMCP("test-interceptors")
+        register_interceptors_list(mcp)
+        route = mcp._custom_starlette_routes[-1]
+        assert route.path == "/interceptors/list"
+
+    def test_registered_route_serves_200(self):
+        mcp = FastMCP("test-interceptors")
+        register_interceptors_list(mcp)
+        app = mcp.streamable_http_app()
+        client = TestClient(app)
+        resp = client.get("/interceptors/list")
+        assert resp.status_code == 200
+        assert "interceptors" in resp.json()


### PR DESCRIPTION
## Why

`GET /interceptors/list` returns 404 because the custom HTTP route is registered on
the `MCPServerFactory`'s FastMCP instance (`"mcp-hangar"`), but `ServerLifecycle`
serves a different FastMCP instance (`"mcp-registry"`) created during bootstrap.
The route never reaches the instance whose Starlette app handles traffic.

Closes #151

## What

- Extract `register_interceptors_list()` from `MCPServerFactory._register_interceptors_list`
  into `interceptors_list.py` as a standalone public function
- Call it from `register_all_tools()` in `server/bootstrap/tools.py` so the route is
  present on the bootstrap FastMCP instance that actually serves traffic
- Update `MCPServerFactory._register_interceptors_list` to delegate to the extracted function
  (factory path still works for direct `create_asgi_app()` usage)
- Fix inaccurate JSON payload example in `INTERCEPTOR_FRAMEWORK.md` to match the actual
  `interceptors_list_response()` output
- Add note that discovery is currently HTTP (not JSON-RPC) pending MCP SDK support

## How tested

- 3 new unit tests in `test_interceptors_list.py`:
  - `test_register_adds_one_custom_route`: verifies exactly one route added to `_custom_starlette_routes`
  - `test_registered_route_path`: verifies the route path is `/interceptors/list`
  - `test_registered_route_serves_200`: boots a `streamable_http_app()` from a FastMCP instance
    with the route registered and confirms `GET /interceptors/list` returns 200 + JSON
- All 10 tests pass (`uv run pytest tests/unit/test_interceptors_list.py -x -q`)
- `uv run mypy` and `uv run ruff check` clean on all changed files
- `uv build` succeeds

## Risk and rollback

Low risk. The fix adds one function call to `register_all_tools()` during bootstrap.
The route handler (`interceptors_list_handler`) is unchanged. Revert the commit to rollback.

## CHANGELOG note

- Fixed: `/interceptors/list` endpoint now reachable at runtime (was 404 due to route registered on wrong FastMCP instance) (#151)

## Agent metadata

- Model: claude-opus-4
- Session: mcp-hangar docs accuracy epic + interceptors fix