### PR TITLE
fix(docs): fix leftover drift in cookbook recipes 02/03/04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **core:** register `/interceptors/list` custom HTTP route on the bootstrap FastMCP instance so the endpoint is reachable at runtime; previously registered only on the factory's instance which is not served by `ServerLifecycle` (#151)
+- **docs:** fix leftover drift in cookbook recipes 02/03/04: drop phantom `health_check.enabled`/`health_check.interval_s` config keys, replace `MCP servers.<name>` with `mcp_servers.<name>` in config tables, remove fictional log strings, replace dead `uvx mcp-server-fetch` with `docker start`, fix `mode: subprocess` in recipe 01 example output (#152)
 - **observability:** restore `trace.set_tracer_provider()` call in `observability/tracing.py:214`; global Provider→McpServer rename had renamed a third-party OpenTelemetry SDK function to `set_tracer_mcp_server`, which does not exist. Tracing initialization had been failing silently in every 1.0.x and 1.1.0 build (fault barrier swallowed the AttributeError and logged at ERROR). Discovered via live smoke test of v1.1.0 in docker-compose.
 - **docs:** remove stale "Metrics Not Yet Implemented" section from OBSERVABILITY.md; all listed metrics are live in `metrics.py` since v1.1.0 (#135)
 - **docs:** replace broken prerequisite shell commands in cookbook recipes 01 and 04 with in-repo `examples/provider_math` Docker image (#128)

--- a/docs/cookbook/01-http-gateway.md
+++ b/docs/cookbook/01-http-gateway.md
@@ -105,7 +105,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` or pass it with `--config`.
    ```
 
    ```json
-   {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"...\"mcp_server\": \"my-mcp\", \"state\": \"ready\", \"mode\": \"subprocess\", \"tools_count\": 2..."}]}}
+   {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"...\"mcp_server\": \"my-mcp\", \"state\": \"ready\", \"mode\": \"remote\", \"tools_count\": 2..."}]}}
    ```
 
    MCP Server transitioned to READY and discovered tools.

--- a/docs/cookbook/02-health-checks.md
+++ b/docs/cookbook/02-health-checks.md
@@ -142,7 +142,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
 
 ## What Just Happened
 
-Hangar's background health check worker probes each READY MCP server every 30 seconds (configured via `health_check.interval_s`). The probe mechanism sends a `tools/list` JSON-RPC request to the MCP server with a 5-second timeout. If the MCP server responds successfully, the health check passes and `consecutive_failures` resets to 0.
+Hangar's background health check worker probes each READY MCP server every 60 seconds. The probe mechanism sends a `tools/list` JSON-RPC request to the MCP server with a 5-second timeout. If the MCP server responds successfully, the health check passes and `consecutive_failures` resets to 0.
 
 When the MCP server fails to respond, Hangar records a failure in the `HealthTracker`. After `max_consecutive_failures` (3 by default) failed checks, the MCP server state transitions from READY to DEGRADED. This transition emits a `McpServerDegraded` domain event, which updates metrics and triggers alerts.
 
@@ -157,9 +157,7 @@ State machine transitions:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `health_check.enabled` | bool | `true` | Enable global health checking |
-| `health_check.interval_s` | int | `30` | Default interval between checks (seconds) |
-| `health_check_interval_s` | int | `60` | Per-MCP server health check interval override |
+| `health_check_interval_s` | int | `30` | Per-MCP server health check interval (seconds) |
 | `max_consecutive_failures` | int | `3` | Failures before state transition to DEGRADED |
 
 ## What's Next

--- a/docs/cookbook/03-circuit-breaker.md
+++ b/docs/cookbook/03-circuit-breaker.md
@@ -74,11 +74,10 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
 
    Circuit breaker is CLOSED (normal operation). Call succeeded.
 
-3. Kill the MCP server to simulate failures
+3. Stop the MCP server to simulate failures
 
    ```bash
-   ps aux | grep mcp-server | grep -v grep
-   kill <PID>
+   docker stop mcp-math
    ```
 
    MCP Server is now dead.
@@ -101,11 +100,11 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
 
    ```
    Attempt 1...
-   WARNING  tool_call_failed mcp_server=my-mcp-group error=Connection refused
+   (error output — connection refused or timeout)
    Attempt 2...
-   WARNING  tool_call_failed mcp_server=my-mcp-group error=Connection refused
+   (error output — connection refused or timeout)
    Attempt 3...
-   WARNING  circuit_breaker_opened group=my-mcp-group failures=3
+   (error output — circuit breaker opened after 3 failures)
    ```
 
    After 3 failures, circuit opens.
@@ -124,7 +123,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
    ```
 
    ```
-   ERROR    call_rejected_circuit_open group=my-mcp-group
+   (error output — request rejected immediately, circuit is open)
 
    real    0m2.1s
    ```
@@ -139,16 +138,12 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
    tail -5 /tmp/hangar-circuit.log
    ```
 
-   ```
-   INFO     circuit_reset_timeout_elapsed group=my-mcp-group
-   ```
-
-   Circuit automatically transitions from OPEN to CLOSED after `reset_timeout_s`.
+   After `reset_timeout_s` elapses, the circuit automatically transitions from OPEN back to CLOSED.
 
 7. Restart MCP server and verify recovery
 
    ```bash
-   uvx mcp-server-fetch &
+   docker start mcp-math
    sleep 2
 
    (
@@ -188,12 +183,12 @@ They complement each other. Health checks catch dead MCP servers. Circuit breake
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `MCP servers.<name>.mode` | string | — | Set to `group` for MCP server groups |
-| `MCP servers.<name>.strategy` | string | `round_robin` | Load balancing strategy |
-| `MCP servers.<name>.min_healthy` | int | `1` | Minimum healthy members required |
-| `MCP servers.<name>.circuit_breaker.failure_threshold` | int | `10` | Consecutive failures before circuit opens |
-| `MCP servers.<name>.circuit_breaker.reset_timeout_s` | float | `60.0` | Seconds before circuit auto-closes |
-| `MCP servers.<name>.members` | list | — | List of MCP server IDs or inline definitions |
+| `mcp_servers.<name>.mode` | string | — | Set to `group` for MCP server groups |
+| `mcp_servers.<name>.strategy` | string | `round_robin` | Load balancing strategy |
+| `mcp_servers.<name>.min_healthy` | int | `1` | Minimum healthy members required |
+| `mcp_servers.<name>.circuit_breaker.failure_threshold` | int | `10` | Consecutive failures before circuit opens |
+| `mcp_servers.<name>.circuit_breaker.reset_timeout_s` | float | `60.0` | Seconds before circuit auto-closes |
+| `mcp_servers.<name>.members` | list | — | List of MCP server IDs or inline definitions |
 
 ## What's Next
 

--- a/docs/cookbook/04-failover.md
+++ b/docs/cookbook/04-failover.md
@@ -94,9 +94,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
    ```
 
    ```
-   INFO     member_added_to_rotation member=my-mcp group=my-mcp-group
-   INFO     member_added_to_rotation member=my-mcp-backup group=my-mcp-group
-   INFO     group_state_changed group=my-mcp-group state=healthy members=2/2
+   (log output showing both members initialized and group ready)
    ```
 
    Both MCP servers in rotation. Primary (priority 1) will handle requests.
@@ -140,7 +138,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
    WARNING  health_check_failed mcp_server=my-mcp consecutive_failures=1
    WARNING  health_check_failed mcp_server=my-mcp consecutive_failures=2
    WARNING  health_check_failed mcp_server=my-mcp consecutive_failures=3
-   INFO     member_removed_from_rotation member=my-mcp reason=health_check_failures
+   (primary removed from rotation after max consecutive failures)
    ```
 
    Primary out of rotation. Backup takes over.
@@ -168,7 +166,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
 
    ```bash
    # Restart primary
-   uvx mcp-server-fetch &
+   docker start mcp-primary
 
    # Wait for recovery
    echo "Waiting 40 seconds for primary recovery..."
@@ -179,9 +177,7 @@ Save this as `~/.config/mcp-hangar/config.yaml` (or update your existing file).
    ```
 
    ```
-   INFO     health_check_passed mcp_server=my-mcp
-   INFO     member_added_to_rotation member=my-mcp reason=health_recovered
-   INFO     group_state_changed group=my-mcp-group state=healthy members=2/2
+   (log output showing primary health check passed and MCP server returning to ready state)
    ```
 
    Primary recovered and back in rotation. Will reclaim traffic (priority 1 < priority 2).
@@ -216,10 +212,10 @@ Both MCP servers have their own health checks and circuit breakers. The group or
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `MCP servers.<name>.strategy` | string | — | Routing strategy. Use `priority` for failover |
-| `MCP servers.<name>.members[].id` | string | — | MCP Server ID (must exist in `MCP servers:` section) |
-| `MCP servers.<name>.members[].priority` | int | `1` | Routing priority (lower number = higher priority) |
-| `MCP servers.<name>.members[].weight` | int | `1` | Weight for weighted strategies (not used with priority) |
+| `mcp_servers.<name>.strategy` | string | — | Routing strategy. Use `priority` for failover |
+| `mcp_servers.<name>.members[].id` | string | — | MCP Server ID (must exist in `mcp_servers:` section) |
+| `mcp_servers.<name>.members[].priority` | int | `1` | Routing priority (lower number = higher priority) |
+| `mcp_servers.<name>.members[].weight` | int | `1` | Weight for weighted strategies (not used with priority) |
 
 ## What's Next
 


### PR DESCRIPTION
## Why

Live cookbook smoke test on 2026-05-11 found residual drift in recipes 02, 03, and 04
that the epic #124 cleanup PRs missed. Phantom config keys, fictional log strings,
dead `uvx` commands, and a find/replace artefact (`MCP servers.<name>` instead of
`mcp_servers.<name>`) survived in the files that earlier PRs didn't sweep.

Closes #152

## What

- **Recipe 01**: Fix `"mode": "subprocess"` to `"mode": "remote"` in example output
  (config uses `mode: remote`)
- **Recipe 02**: Drop phantom `health_check.enabled` and `health_check.interval_s`
  global config keys from Key Config Reference (neither is read anywhere; worker tick
  is hardcoded `HEALTH_CHECK_INTERVAL_SECONDS = 60` in `workers.py:14`). Fix prose
  that said "configured via `health_check.interval_s`".
- **Recipe 03**: Replace `MCP servers.<name>` with `mcp_servers.<name>` in config
  reference table (6 hits). Replace 4 fictional log strings (`tool_call_failed`,
  `circuit_breaker_opened`, `call_rejected_circuit_open`, `circuit_reset_timeout_elapsed`)
  with generic prose. Replace `uvx mcp-server-fetch &` with `docker start mcp-math`.
  Replace `kill <PID>` with `docker stop mcp-math`.
- **Recipe 04**: Same config table fix (4 hits). Replace 3 fictional log strings
  (`member_added_to_rotation`, `member_removed_from_rotation`, `group_state_changed`)
  with generic prose. Replace `uvx mcp-server-fetch &` with `docker start mcp-primary`.
  Keep real `health_check_failed` log strings (verified in `domain/model/mcp_server.py:1199`).

## How tested

- Verified all acceptance criteria from #152:
  - `git grep -nE 'health_check\.(enabled|interval_s)' docs/cookbook/` returns empty
  - `git grep -nE 'MCP servers\.' docs/cookbook/` returns empty (excluding prose)
  - `git grep -nE 'uvx mcp-server-fetch' docs/cookbook/` returns empty
  - All fictional log strings removed; real ones (`health_check_failed`) preserved
  - Recipe 01 example output uses `"mode": "remote"`
- `markdownlint-cli2` passes on all 4 files (0 errors)
- Diff is 25 insertions, 36 deletions (well within 150 LOC limit)

## Risk and rollback

Documentation-only change. No runtime impact. Revert the commit to rollback.

## CHANGELOG note

- Fixed: cookbook recipes 02/03/04 phantom config keys, fictional log strings, dead uvx commands, and find/replace artefacts (#152)

## Agent metadata

- Model: claude-opus-4
- Session: mcp-hangar docs accuracy + core fixes