### PR TITLE
fix(core): replace json.dumps with RFC 8785 JCS canonicalization in compute_tool_digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **core:** **BREAKING** replace `json.dumps` with RFC 8785 JCS canonicalization in `compute_tool_digest`; all previously pinned digests must be recomputed (#171)
+- **core:** reject tool entries with missing, empty, or non-string `name` field in `compute_tool_digest` (#172)
+
 ## [1.2.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.1.0...v1.2.0) (2026-05-11)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "questionary>=2.0.0",
     "python-multipart>=0.0.22",
     "protobuf>=6.33.5",
+    "jcs>=0.2.1",
 ]
 [project.optional-dependencies]
 dev = [

--- a/src/mcp_hangar/domain/services/digest_computation.py
+++ b/src/mcp_hangar/domain/services/digest_computation.py
@@ -2,13 +2,16 @@
 
 Produces deterministic SHA-256 fingerprints from tool schema dicts,
 enabling drift detection and allowlist-based pinning.
+
+Uses RFC 8785 (JCS) canonicalization for cross-SDK interoperability.
 """
 
 from __future__ import annotations
 
 import hashlib
-import json
 from typing import Any
+
+import jcs
 
 from mcp_hangar.domain.value_objects.tool_digest import ToolDigest
 
@@ -16,8 +19,8 @@ from mcp_hangar.domain.value_objects.tool_digest import ToolDigest
 def compute_tool_digest(tool: dict[str, Any]) -> ToolDigest:
     """Compute the canonical SHA-256 digest of a tool schema.
 
-    Canonical form: JSON with sorted keys, no whitespace separators,
-    and only the fields {name, description, inputSchema, outputSchema}.
+    Canonical form: RFC 8785 JCS-serialized JSON containing only the
+    fields {name, description, inputSchema, outputSchema}.
     Fields that are None/missing are omitted from the canonical payload.
 
     Args:
@@ -28,27 +31,20 @@ def compute_tool_digest(tool: dict[str, Any]) -> ToolDigest:
         ToolDigest with the computed sha256 hex string.
 
     Raises:
-        ValueError: If tool has no 'name' key.
+        ValueError: If tool has no 'name' key or name is not a non-empty string.
     """
     name = tool.get("name")
-    if not name:
-        raise ValueError("tool dict must contain a non-empty 'name' key")
+    if not isinstance(name, str) or not name:
+        raise ValueError("tool missing required string field 'name'")
 
     canonical_payload: dict[str, Any] = {"name": name}
 
-    description = tool.get("description")
-    if description is not None:
-        canonical_payload["description"] = description
+    for field in ("description", "inputSchema", "outputSchema"):
+        value = tool.get(field)
+        if value is not None:
+            canonical_payload[field] = value
 
-    input_schema = tool.get("inputSchema")
-    if input_schema is not None:
-        canonical_payload["inputSchema"] = input_schema
-
-    output_schema = tool.get("outputSchema")
-    if output_schema is not None:
-        canonical_payload["outputSchema"] = output_schema
-
-    serialized = json.dumps(canonical_payload, sort_keys=True, separators=(",", ":"))
-    sha256_hex = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    serialized = jcs.canonicalize(canonical_payload)  # bytes, RFC 8785
+    sha256_hex = hashlib.sha256(serialized).hexdigest()
 
     return ToolDigest(tool_name=name, sha256=sha256_hex)

--- a/tests/unit/domain/services/test_digest_computation.py
+++ b/tests/unit/domain/services/test_digest_computation.py
@@ -1,8 +1,8 @@
 """Unit tests for digest computation helper."""
 
-import json
 import hashlib
 
+import jcs
 import pytest
 
 from mcp_hangar.domain.services.digest_computation import compute_tool_digest
@@ -86,22 +86,29 @@ class TestComputeToolDigest:
         result = compute_tool_digest(tool)
         assert result.tool_name == "minimal"
         assert len(result.sha256) == 64
-        # None description = missing description (both omitted from canonical)
         assert compute_tool_digest(tool).sha256 == compute_tool_digest(tool_with_none).sha256
 
     def test_empty_name_raises(self):
-        with pytest.raises(ValueError, match="non-empty 'name'"):
+        with pytest.raises(ValueError, match="'name'"):
             compute_tool_digest({"name": "", "inputSchema": {}})
 
     def test_missing_name_raises(self):
-        with pytest.raises(ValueError, match="non-empty 'name'"):
+        with pytest.raises(ValueError, match="'name'"):
             compute_tool_digest({"description": "no name"})
 
-    def test_canonical_form_matches_manual_computation(self):
+    def test_none_name_raises(self):
+        with pytest.raises(ValueError, match="'name'"):
+            compute_tool_digest({"name": None})
+
+    def test_numeric_name_raises(self):
+        with pytest.raises(ValueError, match="'name'"):
+            compute_tool_digest({"name": 123})
+
+    def test_canonical_form_matches_jcs_reference(self):
         tool = {"name": "t", "description": "d", "inputSchema": {"type": "object"}}
         expected_payload = {"description": "d", "inputSchema": {"type": "object"}, "name": "t"}
-        expected_json = json.dumps(expected_payload, sort_keys=True, separators=(",", ":"))
-        expected_hash = hashlib.sha256(expected_json.encode("utf-8")).hexdigest()
+        expected_bytes = jcs.canonicalize(expected_payload)
+        expected_hash = hashlib.sha256(expected_bytes).hexdigest()
         assert compute_tool_digest(tool).sha256 == expected_hash
 
     def test_unicode_in_description(self):
@@ -109,7 +116,31 @@ class TestComputeToolDigest:
         result = compute_tool_digest(tool)
         assert len(result.sha256) == 64
 
+    def test_non_ascii_emoji_produces_utf8_digest(self):
+        """RFC 8785 requires literal UTF-8, not \\uXXXX escapes."""
+        tool = {"name": "t", "description": "cafe \u0301\U0001f680"}
+        expected_payload = {"description": "cafe \u0301\U0001f680", "name": "t"}
+        expected_bytes = jcs.canonicalize(expected_payload)
+        expected_hash = hashlib.sha256(expected_bytes).hexdigest()
+        result = compute_tool_digest(tool)
+        assert result.sha256 == expected_hash
+
+    def test_non_ascii_differs_from_escaped(self):
+        """Verify JCS literal UTF-8 differs from json.dumps ensure_ascii=True."""
+        import json
+
+        tool = {"name": "t", "description": "cafe \u0301\U0001f680"}
+        canonical_payload = {"description": "cafe \u0301\U0001f680", "name": "t"}
+        ascii_serialized = json.dumps(canonical_payload, sort_keys=True, separators=(",", ":"))
+        ascii_hash = hashlib.sha256(ascii_serialized.encode("utf-8")).hexdigest()
+        jcs_hash = compute_tool_digest(tool).sha256
+        assert jcs_hash != ascii_hash
+
     def test_empty_input_schema(self):
         tool = {"name": "t", "inputSchema": {}}
         result = compute_tool_digest(tool)
         assert len(result.sha256) == 64
+
+    def test_empty_tool_dict_raises(self):
+        with pytest.raises(ValueError, match="'name'"):
+            compute_tool_digest({})

--- a/uv.lock
+++ b/uv.lock
@@ -712,6 +712,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jcs"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/e5/9d547f0d42ba00f68eec773aa7b2145e0c0335eb632cbaf519f480a429af/jcs-0.2.1.tar.gz", hash = "sha256:9f20360b2f3b0a410d65493b448f96306d80e37fb46283f3f4aa5db2c7c1472b", size = 6886, upload-time = "2022-04-10T14:41:24.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/d4/9a99bc15266a842bd14a1913afdb05182888ebab035666c1ce8a64537ca2/jcs-0.2.1-py3-none-any.whl", hash = "sha256:e23a3e1de60f832d33cd811bb9c3b3be79219cdf95f63b88f0972732c3fa8476", size = 7603, upload-time = "2022-04-10T14:41:23.207Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -945,13 +954,14 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "cryptography" },
     { name = "docker" },
     { name = "httpx" },
+    { name = "jcs" },
     { name = "mcp" },
     { name = "prometheus-client" },
     { name = "protobuf" },
@@ -1007,6 +1017,7 @@ requires-dist = [
     { name = "fpdf2", marker = "extra == 'enterprise'", specifier = ">=2.8.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.90.0" },
+    { name = "jcs", specifier = ">=0.2.1" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=2.0.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },


### PR DESCRIPTION
## Why

`compute_tool_digest` uses `json.dumps(..., sort_keys=True)` which has two cross-SDK interop defects:

1. **`ensure_ascii=True` is the default.** Tool descriptions with non-ASCII characters (emoji, accented chars, non-Latin scripts) serialize as `\uXXXX` escapes. RFC 8785 (JCS) requires literal UTF-8. A TypeScript SDK using `JSON.stringify` would produce a different digest for the same tool.
2. **Float serialization diverges.** Python's `json.dumps` for `1e20` does not produce the ES6 `ToString` form mandated by JCS. Tool schemas with float defaults can produce different digests across SDKs.

Additionally, `compute_tool_digest` accepted non-string `name` values (e.g. `123`, `None`) without raising, silently producing a `ToolDigest` with a non-string `tool_name`.

**BREAKING**: All previously pinned digests must be recomputed after this change.

Closes #171
Closes #172
Refs #170

## What

- Replace `json.dumps(canonical_payload, sort_keys=True, separators=(",", ":"))` with `jcs.canonicalize(canonical_payload)` (RFC 8785 reference implementation).
- Add `jcs>=0.2.1` to `pyproject.toml` dependencies.
- Strengthen name validation: `isinstance(name, str)` check rejects `None`, numeric, and other non-string values.
- Add test cases: emoji/non-ASCII digest matches JCS reference, non-ASCII differs from `json.dumps` ASCII-escaped form, `None`/numeric name rejection.

## How tested

- `pytest tests/unit/domain/ -q` -- 295 passed, 0 failed
- New test `test_non_ascii_emoji_produces_utf8_digest` verifies digest matches external JCS reference for `"cafe \u0301\U0001f680"`
- New test `test_non_ascii_differs_from_escaped` verifies JCS output differs from `json.dumps(ensure_ascii=True)`
- New tests for `None`, numeric, empty dict name rejection
- Existing validator tests (15) pass without modification (they use `compute_tool_digest` to build their fixtures, so digest values auto-update)

## Risk and rollback

**Risk**: **HIGH** -- this is a BREAKING change. All previously pinned digests become invalid. Any allowlist configured against v1.2.0 digests will trigger mismatch events after upgrade.
**Mitigation**: CHANGELOG entry warns users to recompute digests. No digest allowlists exist in production yet (feature landed in v1.2.0).
**Rollback**: Revert the merge commit and remove `jcs` dependency.

## CHANGELOG note

- **BREAKING** replace `json.dumps` with RFC 8785 JCS canonicalization in `compute_tool_digest`; all previously pinned digests must be recomputed
- Reject tool entries with missing, empty, or non-string `name` field in `compute_tool_digest`

## Agent metadata

- Agent: Sisyphus (claude-opus-4-20250514)
- Session: mcp-hangar v1.2 post-review fixes epic #170
- Parent issue: #170
- Confidence: high (RFC 8785 reference library, cross-verified against JCS spec)