### PR TITLE
fix(core): disambiguate interceptors/list instance names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **core:** treat `None`, `{}`, `[]`, and `""` as absent when computing tool digests to prevent spurious drift between servers that toggle between missing and empty values (#173)
+- **core:** disambiguate `interceptors/list` instance names to `mcp-hangar-validator` and `mcp-hangar-mutator` per SEP-1763 unique-name requirement (#176)
 
 ## [1.2.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.1.0...v1.2.0) (2026-05-11)
 

--- a/src/mcp_hangar/fastmcp_server/interceptors_list.py
+++ b/src/mcp_hangar/fastmcp_server/interceptors_list.py
@@ -22,7 +22,7 @@ def interceptors_list_response() -> dict[str, Any]:
     return {
         "interceptors": [
             {
-                "name": "mcp-hangar",
+                "name": "mcp-hangar-validator",
                 "version": __version__,
                 "type": "validator",
                 "supportedEvents": ["tools/call", "tools/list"],
@@ -30,7 +30,7 @@ def interceptors_list_response() -> dict[str, Any]:
                 "trustBoundary": "host",
             },
             {
-                "name": "mcp-hangar",
+                "name": "mcp-hangar-mutator",
                 "version": __version__,
                 "type": "mutator",
                 "supportedEvents": ["tools/call"],

--- a/tests/unit/test_interceptors_list.py
+++ b/tests/unit/test_interceptors_list.py
@@ -22,7 +22,7 @@ class TestInterceptorsListResponse:
 
     def test_interceptor_fields(self):
         interceptor = interceptors_list_response()["interceptors"][0]
-        assert interceptor["name"] == "mcp-hangar"
+        assert interceptor["name"] == "mcp-hangar-validator"
         assert isinstance(interceptor["version"], str)
         assert interceptor["type"] == "validator"
         assert interceptor["supportedEvents"] == ["tools/call", "tools/list"]
@@ -31,7 +31,7 @@ class TestInterceptorsListResponse:
 
     def test_mutator_entry(self):
         mutator = interceptors_list_response()["interceptors"][1]
-        assert mutator["name"] == "mcp-hangar"
+        assert mutator["name"] == "mcp-hangar-mutator"
         assert mutator["type"] == "mutator"
         assert mutator["supportedEvents"] == ["tools/call"]
         assert mutator["modes"] == ["enforce"]
@@ -40,6 +40,11 @@ class TestInterceptorsListResponse:
     def test_version_is_nonempty(self):
         interceptor = interceptors_list_response()["interceptors"][0]
         assert len(interceptor["version"]) > 0
+
+    def test_interceptor_names_are_unique(self):
+        data = interceptors_list_response()
+        names = [i["name"] for i in data["interceptors"]]
+        assert len(names) == len(set(names))
 
 
 class TestInterceptorsListEndpoint:


### PR DESCRIPTION
## Why

The SEP-1763 spec defines interceptor `name` as a "Unique identifier" (modelcontextprotocol/experimental-ext-interceptors @ `5bd7ab4`). Both interceptor entries currently share the name `"mcp-hangar"`, violating the uniqueness expectation and blocking T15 CI schema validation.

Part of post-v1.2-review epic #170 (T6).

## What

- Rename validator interceptor from `"mcp-hangar"` to `"mcp-hangar-validator"`.
- Rename mutator interceptor from `"mcp-hangar"` to `"mcp-hangar-mutator"`.
- Add `test_interceptor_names_are_unique` assertion to prevent regression.
- Update existing test assertions to match new names.

## How tested

- `uv run pytest tests/unit/test_interceptors_list.py -x -q` -- 11 passed.

## Risk and rollback

**Low risk.** The `interceptors/list` endpoint is experimental (SEP-1763 draft). No downstream consumers depend on the exact name strings. Revert: `git revert <sha>`.

## CHANGELOG note

- **Fixed:** disambiguate `interceptors/list` instance names to `mcp-hangar-validator` and `mcp-hangar-mutator` per SEP-1763 unique-name requirement (#176)

## Agent metadata

- Agent: Sisyphus (claude-opus-4.6)
- Epic: #170 (post-v1.2-review), Task T6
- Upstream schema pinned: modelcontextprotocol/experimental-ext-interceptors @ 5bd7ab4
- LOC: +10 / -4 (3 files)