### PR TITLE
fix(core): add auth/tls/http config serialization to to_config_dict()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** serialize auth/tls/http config in `to_config_dict()` for remote providers; auth secrets redacted with `[REDACTED]`; hot-reload now detects auth config changes via `_get_mcp_server_spec()`
+
 ### Changed
 - Public documentation migrated to dedicated [docs repository](https://github.com/mcp-hangar/docs). Internal docs remain in `docs/internal/`.
 

--- a/src/mcp_hangar/application/commands/reload_handler.py
+++ b/src/mcp_hangar/application/commands/reload_handler.py
@@ -274,6 +274,9 @@ class ReloadConfigurationHandler(CommandHandler):
             "user": mcp_server._user,
             "description": mcp_server._description,
             "tools": mcp_server._tools.to_dict() if hasattr(mcp_server._tools, "to_dict") else None,
+            "auth": mcp_server._auth_config,
+            "tls": mcp_server._tls_config,
+            "http": mcp_server._http_config,
         }
 
     def _config_differs(self, old_spec: dict[str, Any], new_spec: dict[str, Any]) -> bool:

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1312,11 +1312,35 @@ class McpServer(AggregateRoot):
                 "meta": dict(self._meta),
             }
 
+
+    _SECRET_KEYS = frozenset({"bearer_token", "api_key", "basic_password"})
+
+    @staticmethod
+    def _redact_auth_config(auth: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of auth config with secret values redacted.
+
+        Args:
+            auth: Authentication configuration dict.
+
+        Returns:
+            Copy with sensitive values replaced by [REDACTED].
+        """
+        redacted = {}
+        for k, v in auth.items():
+            if k in McpServer._SECRET_KEYS and isinstance(v, str):
+                redacted[k] = "[REDACTED]"
+            else:
+                redacted[k] = v
+        return redacted
+
     def to_config_dict(self) -> dict[str, Any]:
         """Return YAML-compatible config spec dict.
 
         Returns the minimal representation for round-trip:
         load_config(to_config_dict()) produces an equivalent McpServer.
+        Note: auth secrets are redacted (bearer_token, api_key, basic_password
+        replaced with [REDACTED]) since output is used in API responses and logs.
+        This means the output is NOT suitable for lossless round-trip of secrets.
 
         Returns:
             Dictionary of mcp_server configuration fields, omitting optional
@@ -1345,6 +1369,13 @@ class McpServer(AggregateRoot):
             spec["read_only"] = False
         if self._capabilities is not None:
             spec["capabilities"] = self._capabilities  # Phase 38: serialization in future plan
+        if self._mode == McpServerMode.REMOTE:
+            if self._auth_config:
+                spec["auth"] = self._redact_auth_config(self._auth_config)
+            if self._tls_config:
+                spec["tls"] = dict(self._tls_config)
+            if self._http_config:
+                spec["http"] = dict(self._http_config)
         return spec
 
     def update_config(

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1312,7 +1312,6 @@ class McpServer(AggregateRoot):
                 "meta": dict(self._meta),
             }
 
-
     _SECRET_KEYS = frozenset({"bearer_token", "api_key", "basic_password"})
 
     @staticmethod

--- a/tests/unit/test_reload_handler.py
+++ b/tests/unit/test_reload_handler.py
@@ -157,6 +157,9 @@ class TestReloadConfigurationHandler:
         existing_provider._user = None
         existing_provider._description = None
         existing_provider._tools = Mock(to_dict=lambda: None)
+        existing_provider._auth_config = None
+        existing_provider._tls_config = None
+        existing_provider._http_config = None
         existing_provider.stop.return_value = None
 
         mock_repository.get_all.return_value = {"old-provider": existing_provider}
@@ -205,6 +208,9 @@ class TestReloadConfigurationHandler:
         existing_provider._user = None
         existing_provider._description = None
         existing_provider._tools = Mock(to_dict=lambda: None)
+        existing_provider._auth_config = None
+        existing_provider._tls_config = None
+        existing_provider._http_config = None
         existing_provider.stop.return_value = None
 
         mock_repository.get_all.return_value = {"test-provider": existing_provider}
@@ -260,6 +266,9 @@ class TestReloadConfigurationHandler:
         existing_provider._user = None
         existing_provider._description = None
         existing_provider._tools = Mock(to_dict=lambda: None)
+        existing_provider._auth_config = None
+        existing_provider._tls_config = None
+        existing_provider._http_config = None
 
         mock_repository.get_all.return_value = {"test-provider": existing_provider}
         mock_repository.get.return_value = existing_provider
@@ -314,6 +323,9 @@ class TestReloadConfigurationHandler:
         existing_provider._user = None
         existing_provider._description = None
         existing_provider._tools = Mock(to_dict=lambda: None)
+        existing_provider._auth_config = None
+        existing_provider._tls_config = None
+        existing_provider._http_config = None
         existing_provider.stop.return_value = None
         existing_provider.shutdown.return_value = None
 


### PR DESCRIPTION
## Why

`to_config_dict()` does not serialize auth, TLS, or HTTP config for remote providers, causing information loss in API responses and logs. `_get_mcp_server_spec()` also omits these fields, so hot-reload silently ignores auth config changes. Closes #205.

## What

- Add `_redact_auth_config()` static method to `McpServer` that replaces `bearer_token`, `api_key`, and `basic_password` values with `[REDACTED]`
- Update `to_config_dict()` to include redacted auth, tls, and http config for `mode: remote` providers
- Update docstring to document that output is not suitable for lossless secret round-trip
- Add auth, tls, http fields to `_get_mcp_server_spec()` in `reload_handler.py` so hot-reload detects auth config changes

## How tested

```
uv run pytest tests/unit/test_reload_handler.py -x -q
```

All 8 tests pass. Existing tests for `test_reload_detects_updated_providers` and `test_reload_preserves_unchanged_providers` updated to include the new mock attributes (`_auth_config`, `_tls_config`, `_http_config`).

## Risk and rollback

Low risk. Changes are additive: new fields appear in `to_config_dict()` output only for `mode: remote` providers when the relevant config is non-empty. Revert via single squash commit revert.

## CHANGELOG note

```
### Fixed
- **core:** serialize auth/tls/http config in `to_config_dict()` for remote providers; auth secrets redacted with `[REDACTED]`; hot-reload now detects auth config changes via `_get_mcp_server_spec()`
```

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~80 lines across `mcp_server.py` and `reload_handler.py`
- [x] Files in scope match the issue brief